### PR TITLE
Fixes tab settings window, adds helper control and style targets to simplify xaml

### DIFF
--- a/UnitedSets/App.xaml
+++ b/UnitedSets/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application
+<Application
     x:Class="UnitedSets.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,7 +11,10 @@
                 <ResourceDictionary Source="ms-appx:///Cube.UI/Tabs/GlowTabs.xaml" />
                 <ResourceDictionary Source="ms-appx:///Cube.UI/Styles/WindowChrome.xaml" />
                 <ResourceDictionary Source="ms-appx:///Cube.UI/Styles/CubeUI.xaml" />
-                <!-- Other merged dictionaries here -->
+				<ResourceDictionary>
+					<!-- Fix annoying right margin isssue -->
+					<x:Double x:Key="ToggleSwitchThemeMinWidth">0</x:Double>
+				</ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/UnitedSets/Themes/Generic.xaml
+++ b/UnitedSets/Themes/Generic.xaml
@@ -1,0 +1,19 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:settings="using:UnitedSets.Windows.Flyout.Modules.Tab_Settings"
+    xmlns:local="using:UnitedSets">
+
+	<Style TargetType="settings:SettingsItem" >
+        <Setter Property="Template">
+            <Setter.Value>
+				<ControlTemplate TargetType="settings:SettingsItem">
+					<Grid>
+						<TextBlock Text="{Binding Label, RelativeSource={RelativeSource TemplatedParent}}" FontSize="{Binding LabelSize, RelativeSource={RelativeSource TemplatedParent}}" FontWeight="{Binding LabelWeight, RelativeSource={RelativeSource TemplatedParent}}" VerticalAlignment="Center" />
+						<ContentPresenter HorizontalAlignment="Right"/>
+					</Grid>
+				</ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml
@@ -1,4 +1,4 @@
-﻿<Grid
+<Grid
     x:Class="UnitedSets.Windows.Flyout.Modules.ModifyWindowFlyoutModule"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,72 +6,96 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:communitytoolkitconverters="using:CommunityToolkit.WinUI.UI.Converters"
-    >
+    xmlns:communitytoolkitconverters="using:CommunityToolkit.WinUI.UI.Converters" xmlns:settings="using:UnitedSets.Windows.Flyout.Modules.Tab_Settings">
     <Border BorderThickness="1"
         CornerRadius="8"
         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
         Padding="16">
-        <StackPanel Orientation="Vertical" Spacing="12">
+		<Border.Resources>
+			<ResourceDictionary>
+				<Style TargetType="StackPanel">
+					<Setter Property="Spacing" Value="12" />
+				</Style>
+				<Style TargetType="ToggleSwitch">
+					<Setter Property="OnContent" Value="On" />
+					<Setter Property="OffContent" Value="Off" />
+				</Style>
+				<x:Double x:Key="ToggleSwitchThemeMinWidth">0</x:Double>
+			</ResourceDictionary>
+		</Border.Resources>
+        <StackPanel>	
             <StackPanel.Resources>
                 <communitytoolkitconverters:BoolToVisibilityConverter x:Name="BoolToVisibilityConvertor"/>
             </StackPanel.Resources>
+			
             <TextBlock Text="Window Settings" Style="{StaticResource FlyoutPickerTitleTextBlockStyle}" HorizontalAlignment="Left"/>
-            <Grid>
-                <TextBlock Text="Compatability Mode" HorizontalAlignment="Left"/>
-                <TextBlock x:Name="CompatabilityModeTB" HorizontalAlignment="Right" />
-            </Grid>
-            <Grid x:Name="BorderlessWindowSettings">
-                <Grid>
-                    <TextBlock Text="Borderless Window" FontSize="15" FontWeight="Bold" VerticalAlignment="Center"/>
-                    <ToggleSwitch x:Name="BorderlessToggleSwitch" OnContent="On" OffContent="Off" Margin="0,-5,-80,-5" IsOn="{x:Bind HwndHost.BorderlessWindow, Mode=TwoWay}" HorizontalAlignment="Right" Toggled="OnBorderlessToggleSwitchToggled"/>
-                </Grid>
-                <StackPanel Orientation="Vertical" Spacing="12" x:Name="BorderlessSettingsStackPanel" Visibility="Collapsed">
-                    <Grid>
-                        <TextBlock Text="Window Crop Margin" FontSize="15" FontWeight="Bold" VerticalAlignment="Center"/>
-                        <ToggleSwitch x:Name="WindowCropMarginToggleSwitch" OnContent="On" OffContent="Off" Margin="0,-5,-80,-5" IsOn="{x:Bind HwndHost.ActivateCrop, Mode=TwoWay}" HorizontalAlignment="Right" Toggled="OnWindowCropMarginToggleSwitchToggled"/>
-                    </Grid>
-                    <StackPanel Orientation="Vertical" Spacing="12" x:Name="WindowCropMarginSettingsStackPanel" Visibility="Collapsed">
-                        <Grid>
-                            <TextBlock Text="Top: " VerticalAlignment="Center" HorizontalAlignment="Left"/>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-                                <Button Click="TopMarginShortcutClick">32</Button>
-                                <Button Click="TopMarginShortcutClick">40</Button>
-                                <Button Click="TopMarginShortcutClick">41</Button>
-                                <NumberBox x:Name="TopCropMargin" Value="{x:Bind HwndHost.CropTop, Mode=TwoWay}" SpinButtonPlacementMode="Compact" Minimum="0" MinWidth="100"/>
-                                <Button Padding="5" Tag="{x:Bind TopCropMargin}" Click="OnResetClick">
-                                    <SymbolIcon Symbol="Undo"/>
-                                </Button>
-                            </StackPanel>
-                        </Grid>
-                        <Grid>
-                            <TextBlock Text="Left: " VerticalAlignment="Center" HorizontalAlignment="Left"/>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-                                <NumberBox x:Name="LeftCropMargin" Value="{x:Bind HwndHost.CropLeft, Mode=TwoWay}" SpinButtonPlacementMode="Compact" Minimum="0" MinWidth="100"/>
-                                <Button Padding="5" Tag="{x:Bind LeftCropMargin}" Click="OnResetClick">
-                                    <SymbolIcon Symbol="Undo"/>
-                                </Button>
-                            </StackPanel>
-                        </Grid>
-                        <Grid>
-                            <TextBlock Text="Right: " VerticalAlignment="Center" HorizontalAlignment="Left"/>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-                                <NumberBox x:Name="RightCropMargin" Value="{x:Bind HwndHost.CropRight, Mode=TwoWay}" SpinButtonPlacementMode="Compact" Minimum="0" MinWidth="100"/>
-                                <Button Padding="5" Tag="{x:Bind RightCropMargin}" Click="OnResetClick">
-                                    <SymbolIcon Symbol="Undo"/>
-                                </Button>
-                            </StackPanel>
-                        </Grid>
-                        <Grid>
-                            <TextBlock Text="Bottom: " VerticalAlignment="Center" HorizontalAlignment="Left"/>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
-                                <NumberBox x:Name="BottomCropMargin" Value="{x:Bind HwndHost.CropBottom, Mode=TwoWay}" SpinButtonPlacementMode="Compact" Minimum="0" MinWidth="100"/>
-                                <Button Padding="5" Tag="{x:Bind BottomCropMargin}" Click="OnResetClick">
-                                    <SymbolIcon Symbol="Undo"/>
-                                </Button>
-                            </StackPanel>
-                        </Grid>
+			<settings:SettingsItem Label="Compatability Mode">
+				<TextBlock x:Name="CompatabilityModeTB" />
+			</settings:SettingsItem>
+			<settings:SettingsItem Label="Borderless Window" LabelSize="15" LabelWeight="Bold" Visibility="{Binding ElementName=BorderlessWindowSettings, Path=Visibility}">
+				<ToggleSwitch x:Name="BorderlessToggleSwitch"  IsOn="{x:Bind HwndHost.BorderlessWindow, Mode=TwoWay}" Toggled="OnBorderlessToggleSwitchToggled" />
+			</settings:SettingsItem>
+			<Grid x:Name="BorderlessWindowSettings">
+                <StackPanel x:Name="BorderlessSettingsStackPanel" Visibility="Collapsed">
+					<settings:SettingsItem Label="Window Crop Margin" LabelSize="15" LabelWeight="Bold">
+						<ToggleSwitch x:Name="WindowCropMarginToggleSwitch" IsOn="{x:Bind HwndHost.ActivateCrop, Mode=TwoWay}" Toggled="OnWindowCropMarginToggleSwitchToggled" />
+					</settings:SettingsItem>
+
+					<StackPanel x:Name="WindowCropMarginSettingsStackPanel" Visibility="Collapsed" HorizontalAlignment="Stretch" Orientation="Vertical" Spacing="12">
+
+						<StackPanel.Resources>
+							<Style TargetType="StackPanel">
+								<Setter Property="Spacing" Value="8" />
+								<Setter Property="Orientation" Value="Horizontal" />
+							</Style>
+							<Style TargetType="NumberBox">
+								<Setter Property="SpinButtonPlacementMode" Value="Compact" />
+								<Setter Property="Minimum" Value="0" />
+								<Setter Property="MinWidth" Value="100" />
+							</Style>
+
+							<Style TargetType="Button">
+								<Setter Property="Padding" Value="5" />
+							</Style>
+
+						</StackPanel.Resources>
+							<settings:SettingsItem Label="Top:">
+								<StackPanel>
+									<Button Background="LightBlue" Click="TopMarginShortcutClick">32</Button>
+									<Button Background="LightBlue" Click="TopMarginShortcutClick">40</Button>
+									<Button Background="LightBlue" Click="TopMarginShortcutClick">41</Button>
+									<NumberBox x:Name="TopCropMargin" Value="{x:Bind HwndHost.CropTop, Mode=TwoWay}"/>
+									<Button Tag="{x:Bind TopCropMargin}" Click="OnResetClick">
+										<SymbolIcon Symbol="Undo"/>
+									</Button>
+								</StackPanel>
+							</settings:SettingsItem>
+							<settings:SettingsItem Label="Left:">
+								<StackPanel>
+									<NumberBox x:Name="LeftCropMargin" Value="{x:Bind HwndHost.CropLeft, Mode=TwoWay}" />
+									<Button Tag="{x:Bind LeftCropMargin}" Click="OnResetClick">
+										<SymbolIcon Symbol="Undo"/>
+									</Button>
+								</StackPanel>
+							</settings:SettingsItem>
+						<settings:SettingsItem Label="Right:">
+							<StackPanel>
+								<NumberBox x:Name="RightCropMargin" Value="{x:Bind HwndHost.CropRight, Mode=TwoWay}" />
+								<Button Tag="{x:Bind RightCropMargin}" Click="OnResetClick">
+									<SymbolIcon Symbol="Undo"/>
+								</Button>
+							</StackPanel>
+						</settings:SettingsItem>
+						<settings:SettingsItem Label="Bottom:">
+							<StackPanel>
+								<NumberBox x:Name="BottomCropMargin" Value="{x:Bind HwndHost.CropBottom, Mode=TwoWay}" />
+								<Button Tag="{x:Bind BottomCropMargin}" Click="OnResetClick">
+									<SymbolIcon Symbol="Undo"/>
+								</Button>
+							</StackPanel>
+						</settings:SettingsItem>
+
                     </StackPanel>
                 </StackPanel>
             </Grid>

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/SettingsItem.cs
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/SettingsItem.cs
@@ -1,0 +1,33 @@
+using Microsoft.UI.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Text;
+
+namespace UnitedSets.Windows.Flyout.Modules.Tab_Settings {
+	public sealed class SettingsItem : ContentControl
+    {
+        public SettingsItem()
+        {
+            this.DefaultStyleKey = typeof(SettingsItem);
+        }
+		public string Label {
+			get { return (string)GetValue(LabelProperty); }
+			set { SetValue(LabelProperty, value); }
+		}
+
+		public static readonly DependencyProperty LabelProperty = DependencyProperty.Register("Label", typeof(string), typeof(SettingsItem), new PropertyMetadata(""));
+		public FontWeight LabelWeight {
+			get { return (FontWeight)GetValue(LabelWeightProperty); }
+			set { SetValue(LabelWeightProperty, value); }
+		}
+
+		public static readonly DependencyProperty LabelWeightProperty = DependencyProperty.Register("LabelWeight", typeof(FontWeight), typeof(SettingsItem), new PropertyMetadata(FontWeights.Normal));
+
+		public double LabelSize {
+			get { return (double)GetValue(LabelSizeProperty); }
+			set { SetValue(LabelSizeProperty, value); }
+		}
+
+		public static readonly DependencyProperty LabelSizeProperty = DependencyProperty.Register("LabelSize", typeof(double), typeof(SettingsItem), new PropertyMetadata(14));
+	}
+}


### PR DESCRIPTION
I am not sure how much was the DPI settings for me with the hard margins vs a few minor xaml overlap errors but the settings window was pretty hard to use before on my screen.  Also set the colors on the top defaults to make it more obvious they are not textboxes.