### PR TITLE
Thread safety, detaching and disposal improvements

### DIFF
--- a/UnitedSets/Classes/Tab/TabBase.cs
+++ b/UnitedSets/Classes/Tab/TabBase.cs
@@ -1,4 +1,4 @@
-﻿using EasyCSharp;
+using EasyCSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -50,7 +50,7 @@ public abstract partial class TabBase : INotifyPropertyChanged
 
                 try
                 {
-                    foreach (var tab in AllTabs)
+                    foreach (var tab in AllTabs.ToArray())
                     {
                         if (tab.IsDisposed) AllTabs.Remove(tab);
                         else tab.UpdateStatusLoop();

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml.cs
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml.cs
@@ -1,4 +1,4 @@
-﻿using EasyCSharp;
+using EasyCSharp;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System.Diagnostics;
@@ -49,10 +49,7 @@ public sealed partial class ModifyWindowFlyoutModule : IWindowFlyoutModule
     {
         if (!WindowCropMarginToggleSwitch.IsOn)
         {
-            TopCropMargin.Value =
-            BottomCropMargin.Value =
-            LeftCropMargin.Value =
-            RightCropMargin.Value = 0;
+			HwndHost.ClearCrop();
         }
         WindowCropMarginSettingsStackPanel.Visibility = WindowCropMarginToggleSwitch.IsOn ? Visibility.Visible : Visibility.Collapsed;
     }

--- a/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
+++ b/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
@@ -220,25 +220,29 @@ public sealed partial class MainWindow : INotifyPropertyChanged
         SecondaryButtonText = "Close all Windows",
         CloseButtonText = "Cancel"
     };
+	async Task TimerStop() {
+		timer.Stop();
+		OnTimerLoopTick();
+		await Task.Delay(100);
+	}
 
     [Event(typeof(TypedEventHandler<AppWindow, AppWindowClosingEventArgs>))]
     async void OnWindowClosing(AppWindowClosingEventArgs e)
     {
-        e.Cancel = true;
+        e.Cancel = true;//as we will just exit if we want to actually close
         ClosingWindowDialog.XamlRoot = Content.XamlRoot;
         var item = TabView.SelectedItem;
         TabView.SelectedIndex = -1;
         TabView.Visibility = Visibility.Collapsed;
         WindowEx.Focus();
-        ContentDialogResult result;
-        try
-        {
-            result = await ClosingWindowDialog.ShowAsync();
-        }
-        catch
-        {
-            result = ContentDialogResult.None;
-        }
+		ContentDialogResult result = ContentDialogResult.Primary;
+		if (Tabs.Count > 0) {
+			try {
+				result = await ClosingWindowDialog.ShowAsync();
+			} catch {
+				result = ContentDialogResult.None;
+			}
+		}
         switch (result)
         {
             case ContentDialogResult.Primary:
@@ -249,7 +253,9 @@ public sealed partial class MainWindow : INotifyPropertyChanged
                     Tabs.RemoveAt(0);
                     Tab.DetachAndDispose(JumpToCursor: false);
                 }
-                Environment.Exit(0);
+				await TimerStop();
+
+				Environment.Exit(0);
                 return;
             case ContentDialogResult.Secondary:
                 // Close all windows
@@ -275,7 +281,8 @@ public sealed partial class MainWindow : INotifyPropertyChanged
                 }
                 if (Tabs.Count == 0)
                 {
-                    Environment.Exit(0);
+					await TimerStop();
+					Environment.Exit(0);
                     return;
                 }
                 goto default;

--- a/WinUI3HwndHostPlus/DispatcherQueueExtensions.cs
+++ b/WinUI3HwndHostPlus/DispatcherQueueExtensions.cs
@@ -1,0 +1,271 @@
+// https://raw.githubusercontent.com/CommunityToolkit/WindowsCommunityToolkit/main/Microsoft.Toolkit.Uwp/Extensions/DispatcherQueueExtensions.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Windows.Foundation.Metadata;
+
+
+#nullable enable
+
+namespace Microsoft.Toolkit.Uwp
+{
+    /// <summary>
+    /// Helpers for executing code in a <see cref="DispatcherQueue"/>.
+    /// </summary>
+    public static class DispatcherQueueExtensions
+    {
+        /// <summary>
+        /// Indicates whether or not <see cref="DispatcherQueue.HasThreadAccess"/> is available.
+        /// </summary>
+        private static readonly bool IsHasThreadAccessPropertyAvailable = ApiInformation.IsMethodPresent("Windows.System.DispatcherQueue", "HasThreadAccess");
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task"/> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Action"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="function"/> is over.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task EnqueueAsync(this DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // Run the function directly when we have thread access.
+            // Also reuse Task.CompletedTask in case of success,
+            // to skip an unnecessary heap allocation for every invocation.
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    function();
+
+                    return Task.CompletedTask;
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueueAsync(DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(priority, () =>
+                {
+                    try
+                    {
+                        function();
+
+                        taskCompletionSource.SetResult(null);
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task{TResult}"/> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <typeparam name="T">The return type of <paramref name="function"/> to relay through the returned <see cref="Task{TResult}"/>.</typeparam>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="function"/> is over.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task<T> EnqueueAsync<T>(this DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    return Task.FromResult(function());
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
+            }
+
+            static Task<T> TryEnqueueAsync(DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>();
+
+                if (!dispatcher.TryEnqueue(priority, () =>
+                {
+                    try
+                    {
+                        taskCompletionSource.SetResult(function());
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task"/> that acts as a proxy for the one returned by the given function.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that acts as a proxy for the one returned by <paramref name="function"/>.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task EnqueueAsync(this DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // If we have thread access, we can retrieve the task directly.
+            // We don't use ConfigureAwait(false) in this case, in order
+            // to let the caller continue its execution on the same thread
+            // after awaiting the task returned by this function.
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    if (function() is Task awaitableResult)
+                    {
+                        return awaitableResult;
+                    }
+
+                    return Task.FromException(GetEnqueueException("The Task returned by function cannot be null."));
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueueAsync(DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(priority, async () =>
+                {
+                    try
+                    {
+                        if (function() is Task awaitableResult)
+                        {
+                            await awaitableResult.ConfigureAwait(false);
+
+                            taskCompletionSource.SetResult(null);
+                        }
+                        else
+                        {
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task{TResult}"/> that acts as a proxy for the one returned by the given function.
+        /// </summary>
+        /// <typeparam name="T">The return type of <paramref name="function"/> to relay through the returned <see cref="Task{TResult}"/>.</typeparam>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that relays the one returned by <paramref name="function"/>.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task<T> EnqueueAsync<T>(this DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    if (function() is Task<T> awaitableResult)
+                    {
+                        return awaitableResult;
+                    }
+
+                    return Task.FromException<T>(GetEnqueueException("The Task returned by function cannot be null."));
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
+            }
+
+            static Task<T> TryEnqueueAsync(DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>();
+
+                if (!dispatcher.TryEnqueue(priority, async () =>
+                {
+                    try
+                    {
+                        if (function() is Task<T> awaitableResult)
+                        {
+                            var result = await awaitableResult.ConfigureAwait(false);
+
+                            taskCompletionSource.SetResult(result);
+                        }
+                        else
+                        {
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="InvalidOperationException"/> to return when an enqueue operation fails.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        /// <returns>An <see cref="InvalidOperationException"/> with a specified message.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetEnqueueException(string message)
+        {
+            return new InvalidOperationException(message);
+        }
+    }
+}

--- a/WinUI3HwndHostPlus/HwndHost.UpdateLoop.cs
+++ b/WinUI3HwndHostPlus/HwndHost.UpdateLoop.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using WindowEx = WinWrapper.Window;
 using WinWrapper;
 using System.Linq;
@@ -9,6 +9,10 @@ namespace WinUI3HwndHostPlus;
 partial class HwndHost
 {
     int CountDown = 5;
+	public async void ClearCrop() {
+		CropLeft = CropRight = CropBottom = CropTop = 0;
+		await _HostedWindow.SetRegionAsync(null);//could do initial region as well
+	}
     async void OnWindowUpdate()
     {
         if (_CacheWidth == 0 || _CacheHeight == 0) return; // wait for update
@@ -41,7 +45,8 @@ partial class HwndHost
 
         try
         {
-            WindowToHost.IsResizable = false;
+			if (WindowToHost.IsResizable)
+				WindowToHost.IsResizable = false;
         }
         catch
         {
@@ -67,7 +72,7 @@ partial class HwndHost
             {
                 if (Check && WindowEx.ForegroundWindow == WindowToHost)
                 {
-                    DetachAndDispose();
+                    await DetachAndDispose();
                     return;
                 }
                 else WindowToHost.Bounds = newBounds;

--- a/WinUI3HwndHostPlus/HwndHost.cs
+++ b/WinUI3HwndHostPlus/HwndHost.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml;
 using System;
 using Microsoft.UI.Windowing;
 using System.Drawing;
@@ -7,13 +7,18 @@ using Windows.Win32.UI.WindowsAndMessaging;
 using Windows.Win32;
 using Windows.Win32.Graphics.Dwm;
 using EasyCSharp;
+using Windows.UI.Core;
+using Microsoft.UI.Dispatching;
 
 namespace WinUI3HwndHostPlus;
 
 public partial class HwndHost : FrameworkElement, IDisposable
 {
     readonly Window XAMLWindow;
-    readonly AppWindow WinUIAppWindow;
+
+	private DispatcherQueue UIDispatcher;
+
+	readonly AppWindow WinUIAppWindow;
     
     public HwndHost(Window XAMLWindow, WindowEx WindowToHost)
     {
@@ -22,8 +27,11 @@ public partial class HwndHost : FrameworkElement, IDisposable
         InitialRegion = WindowToHost.Region;
         
         this.XAMLWindow = XAMLWindow;
+		
+		this.UIDispatcher = XAMLWindow.DispatcherQueue;//caching incase our window dies
 
-        var WinUIHandle = WinRT.Interop.WindowNative.GetWindowHandle(XAMLWindow);
+
+		var WinUIHandle = WinRT.Interop.WindowNative.GetWindowHandle(XAMLWindow);
         _ParentWindow = WindowEx.FromWindowHandle(WinUIHandle);
         WinUIAppWindow = AppWindow.GetFromWindowId(
             Microsoft.UI.Win32Interop.GetWindowIdFromWindow(


### PR DESCRIPTION
Added AsyncEnqueue for the DispatcherQueue from the community toolkit.

A series of changes to improve the reliability, mostly around window detaching/removal.  

Thread safety and 'disposal' are the primary areas of concentration.    With these changes I find it much more reliable on detach/close to restoring windows to original states.

Note this requires https://github.com/Get0457/WinWrapper/pull/3 to be merged to compile per the notes below (work around also below).

A more detailed set of notes that might help with why on some of the code changes:
## Collection Safety
In several spots (specifically tab) collections are enumerated while they could end up changed by another thread or as we desire to remove it directly. I think this is also why several of the loops had breaks in them after single item removal.  To get around the enumerating a modified collection just casting the items to an array at the start resolves.  As ObservableCollection is not thread safe to make sure notifications happen any modification we should trigger on the UI thread using DispatcherQueue.

## UI Thread Queuing 
Added EnqueueAsync helper for DispatcherQueue from the Community Toolkit allows us to wait for the tasks to run (similar to CoreDispatcher).  EnqueueAsync has perf check so only actually queues into DispatcherQueue if we are not on the UI thread. 

Cache the DispatcherQueue on window creation is a fairly safe way to maintain reference to the UI threads queue without requiring an instance to stay around.

## Crop Clearing
The crop was not getting unset when toggled off. Once off even though crop is set to 0 it isn't executed to be unset as the update loop itself only calls if ActivateCrop is enabled.  While we could work around this rather than rely on the update loop we can clear the crop manually when we turn ActivateCrop off.  This adds a ClearCrop command to the HwndHost.  Note right now it is setting crop to NULL (completely reset) rather than using InitialCrop.  I went back and forth here, but if somehow the crop was set by something else or some race condition with another instance of us, clearing the crop completely seemed like the best expected action (guaranteed to undo any crop that would otherwise ruin the window).   This requires https://github.com/Get0457/WinWrapper/pull/3 to be applied before it will work (not only does it not allow NULL passing currently but the older ms PInvoke lib has a bug where even when told to send NULL it actually sent -1).  If that may not happen soon we could just call SetWindowRgn with the right size and 0,0 to do similar.

## Disposal
When a tab is detached we want to really work to restore everything back to how it was.  I updated the order to go in the same reversal order.  