### PR TITLE
DragDrop InvalidCast fix for W10

### DIFF
--- a/UnitedSets/Classes/Cell.UI.Events.cs
+++ b/UnitedSets/Classes/Cell.UI.Events.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Microsoft.UI.Xaml;
 using System.Linq;
 using System;
@@ -14,27 +14,21 @@ partial class Cell
     public void OnDragOver(DragEventArgs e)
     {
         // There MUST BE NO SUBCELL AND CURRNETCELL
-        if (!Empty) return;
-        DataPackageView dataview = e.DataView;
-        var formats = dataview.AvailableFormats.ToList();
-        if (formats.Contains("UnitedSetsTabWindow"))
-            e.AcceptedOperation = DataPackageOperation.Move;
+        if (!Empty || !e.DataView.Properties.ContainsKey(MainWindow.UnitedSetsTabWindowDragProperty)) return;
+        e.AcceptedOperation = DataPackageOperation.Move;
     }
 
     [Event(typeof(DragEventHandler), Name = "DropEv")]
-    public async void OnItemDrop(DragEventArgs e)
+    public void OnItemDrop(DragEventArgs e)
     {
         // There MUST BE NO SUBCELL AND CURRNETCELL
-        if (!Empty) return;
-        DataPackageView dataview = e.DataView;
-        var formats = dataview.AvailableFormats.ToList();
-        if (formats.Contains("UnitedSetsTabWindow"))
-        {
-            var hwnd = (long)await e.DataView.GetDataAsync("UnitedSetsTabWindow");
-            var window = Window.FromWindowHandle((nint)hwnd);
-            var ret = PInvoke.SendMessage(window.Owner, MainWindow.UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
-            RegisterWindow(window);
-        }
+		if (!Empty || !e.DataView.Properties.TryGetValue(MainWindow.UnitedSetsTabWindowDragProperty, out var _a) || _a is long hwnd == false)
+			return;
+
+		var window = Window.FromWindowHandle((nint)hwnd);
+		var ret = PInvoke.SendMessage(window.Owner, MainWindow.UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
+		RegisterWindow(window);
+
     }
 
     [Event(typeof(RoutedEventHandler), Name = "AddCellAddCountClickEv")]

--- a/UnitedSets/Windows/Flyout/Modules/MainWindowMenuFlyoutModule.xaml.cs
+++ b/UnitedSets/Windows/Flyout/Modules/MainWindowMenuFlyoutModule.xaml.cs
@@ -1,4 +1,4 @@
-﻿using EasyCSharp;
+using EasyCSharp;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
@@ -157,14 +157,14 @@ public sealed partial class MainWindowMenuFlyoutModule : Grid, IWindowFlyoutModu
     {
         if (args.Items.Count is not 0) return;
         if (args.Items[0] is HwndHostTab item)
-            args.Data.SetData(MainWindow.UnitedSetsTabWindowDragProperty, (long)item.Window.Handle.Value);
+            args.Data.Properties.Add(MainWindow.UnitedSetsTabWindowDragProperty, (long)item.Window.Handle.Value);
     }
 
 
     [Event(typeof(DragEventHandler))]
     void OnDragItemOverTabListView(DragEventArgs e)
     {
-        if (e.DataView.AvailableFormats.Contains(MainWindow.UnitedSetsTabWindowDragProperty))
+        if (e.DataView.Properties.ContainsKey(MainWindow.UnitedSetsTabWindowDragProperty))
             e.AcceptedOperation = DataPackageOperation.Move;
     }
 #pragma warning restore CA1822 // Mark members as static
@@ -174,16 +174,15 @@ public sealed partial class MainWindowMenuFlyoutModule : Grid, IWindowFlyoutModu
         TabListView.SelectedItem = listviewitem.Tag;
     }
     [Event(typeof(DragEventHandler))]
-    async void OnDropItemOverTabListView(DragEventArgs e)
+    void OnDropItemOverTabListView(DragEventArgs e)
     {
         const string UnitedSetsTabWindowDragProperty = MainWindow.UnitedSetsTabWindowDragProperty;
 
-        if (e.DataView.AvailableFormats.Contains(UnitedSetsTabWindowDragProperty))
-        {
-            var pt = e.GetPosition(TabListView);
+		if (e.DataView.Properties.TryGetValue(UnitedSetsTabWindowDragProperty, out var _a) && _a is long a)
+		{
+			var pt = e.GetPosition(TabListView);
             if (TabGroupListView.SelectedIndex is -1) return;
             var tabgroup = MainWindow.HiddenTabs[TabGroupListView.SelectedIndex];
-            var a = (long)await e.DataView.GetDataAsync(UnitedSetsTabWindowDragProperty);
             var window = Window.FromWindowHandle((nint)a);
             var finalIdx = (
                 from index in Enumerable.Range(0, tabgroup.Tabs.Count)

--- a/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
+++ b/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
@@ -32,6 +32,7 @@ using System.Diagnostics.CodeAnalysis;
 using UnitedSets.Windows.Flyout;
 using UnitedSets.Classes.Tabs;
 using UnitedSets.Windows.Flyout.Modules;
+using Microsoft.VisualBasic.Logging;
 
 namespace UnitedSets.Windows;
 
@@ -153,15 +154,15 @@ public sealed partial class MainWindow : INotifyPropertyChanged
     void TabDragStarting(TabViewTabDragStartingEventArgs args)
     {
         if (args.Item is HwndHostTab item)
-            args.Data.SetData(UnitedSetsTabWindowDragProperty, (long)item.Window.Handle.Value);
-    }
+			args.Data.Properties.Add(UnitedSetsTabWindowDragProperty, (long)item.Window.Handle.Value);
+	}
 
 
     [Event(typeof(DragEventHandler))]
     void OnDragItemOverTabView(DragEventArgs e)
     {
-        if (e.DataView.AvailableFormats.Contains(UnitedSetsTabWindowDragProperty))
-            e.AcceptedOperation = DataPackageOperation.Move;
+		if (e.DataView.Properties?.ContainsKey(UnitedSetsTabWindowDragProperty) == true)
+			e.AcceptedOperation = DataPackageOperation.Move;
     }
 #pragma warning restore CA1822 // Mark members as static
 
@@ -173,11 +174,11 @@ public sealed partial class MainWindow : INotifyPropertyChanged
     }
 
     [Event(typeof(DragEventHandler))]
-    async void OnDropOverTabView(DragEventArgs e)
+    void OnDropOverTabView(DragEventArgs e)
     {
-        if (e.DataView.AvailableFormats.Contains(UnitedSetsTabWindowDragProperty))
+		if (e.DataView.Properties.TryGetValue(UnitedSetsTabWindowDragProperty, out var _a) && _a is long a)
         {
-            var a = (long)await e.DataView.GetDataAsync(UnitedSetsTabWindowDragProperty);
+
             var window = WindowEx.FromWindowHandle((nint)a);
             var ret = PInvoke.SendMessage(window.Owner, UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
             var pt = e.GetPosition(TabView);


### PR DESCRIPTION
Switch drag data to be stored in the Properties rather than datatype itself

On windows 10 19041 I am seeing https://github.com/microsoft/CsWinRT/issues/807  clearly drag drop must be fixed on W11 as I assume dragdrop works in app on some platform.   This fix transitions keeping the dragdrop data as a format to be stored as a property.  We are storing relatively little data so I do not see any downside to this transition.

Simplified some of the casting/conditionals as well.