### PR TITLE
Icon for Unpackaged, Moved FauxSettings to own class and write settings to json, Additional debug options

### DIFF
--- a/UnitedSets/Classes/FauxSettings.cs
+++ b/UnitedSets/Classes/FauxSettings.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+#if UNPKG
+
+namespace UnitedSets.Classes {
+	internal class FauxSettings {
+
+		protected const string settings_filename = "our_settings.json";
+		public FauxSettings() {
+			if (File.Exists(SettingsFilePortable)) {
+				SettingsFile = SettingsFilePortable;
+				LoadSettings(SettingsFilePortable);
+			} else if (File.Exists(SettingsFileNormal)) {
+				SettingsFile = SettingsFileNormal;
+				LoadSettings(SettingsFilePortable);
+			}
+			Values.SettingChanged += Values_SettingChanged;
+		}
+
+		private async void Values_SettingChanged(object? sender, string e) {
+			var us = CurSaving = new object();
+			await System.Threading.Tasks.Task.Delay(500);
+			if (us == CurSaving)
+				SaveSettings();
+		}
+		private object CurSaving;
+		private void LoadSettings(string file) {
+			try {
+				var dict = JsonSerializer.Deserialize<ConcurrentDictionary<string, FauxValues.DataVal>>(File.ReadAllText(file));
+				if (dict == null)
+					return;
+				Values.dict = dict;
+			} catch { }
+		}
+		public void SaveSettings() {
+			SettingsFile ??= SettingsFilePortable;//for now we will ust always default to portable if normal does not exist unless we cnanot write
+
+			var serialized = JsonSerializer.Serialize(Values.dict);
+			try {
+				File.WriteAllText(SettingsFile, serialized);
+			} catch (Exception) {
+				if (SettingsFile != SettingsFileNormal) {
+					SettingsFile = SettingsFileNormal;
+					Directory.CreateDirectory(SettingsFileNormal);
+					SaveSettings();
+				}
+
+			}
+
+
+		}
+		private string SettingsFile;
+		private string SettingsFilePortable => System.IO.Path.Combine(Path, settings_filename);
+		private string SettingsFileNormal => System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), System.Reflection.Assembly.GetExecutingAssembly().GetName().Name, settings_filename);
+		public FauxSettings Current => this;
+		public FauxSettings InstalledLocation => this;
+		public string Path => System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+		public class FauxValues {
+			public class DataVal {
+				public string type { get; set; }
+				public object value { get; set; }
+			}
+			public ConcurrentDictionary<string, DataVal> dict = new();
+			public object this[string key] {
+				get {
+					if (dict.TryGetValue(key, out var value) && value != null) {
+						if (value.value is JsonElement je)
+							value.value = je.Deserialize(Type.GetType(value.type));
+						return value.value;
+					}
+					dict[key] = null;
+					return null;
+				}
+				set {
+					var orig = this[key];
+					if (orig == value)
+						return;
+					dict[key] = new DataVal { type = value.GetType().FullName, value = value };
+					SettingChanged?.Invoke(this, key);
+				}
+			}
+			public event EventHandler<string> SettingChanged;
+		}
+		public FauxValues Values = new();
+	}
+}
+#endif

--- a/UnitedSets/Properties/launchSettings.json
+++ b/UnitedSets/Properties/launchSettings.json
@@ -1,16 +1,22 @@
 {
   "profiles": {
-    "UnitedSets (Package)": {
+    "UnitedSets (Packaged)": {
       "commandName": "MsixPackage",
       "nativeDebugging": false
     },
-    "UnitedSets (Unpackaged)": {
-      "commandName": "Project"
-    },
-    "AddNotepad": {
+    "AddNotepad (Packaged)": {
       "commandName": "MsixPackage",
       "commandLineArgs": "--add-window-by-exe notepad --edit-last-added --edit-no-autoclose",
       "nativeDebugging": false
-    }
+    },    
+    "UnitedSets (Unpackaged) Must Use DebugUnpackaged Config": {
+      "commandName": "Project",
+      "nativeDebugging": false
+    },
+    "AddNotepad (Unpackaged) Must Use DebugUnpackaged Config": {
+      "commandName": "Project",
+      "commandLineArgs": "--add-window-by-exe notepad --edit-last-added --edit-no-autoclose",
+      "nativeDebugging": false
+    },  
   }
 }

--- a/UnitedSets/Services/SettingsService.cs
+++ b/UnitedSets/Services/SettingsService.cs
@@ -1,12 +1,9 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EasyCSharp;
-using Microsoft.UI.Xaml;
 using System.Threading;
 using Windows.Storage;
 using UnitedSets.Windows;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace UnitedSets.Services;
@@ -32,27 +29,7 @@ public partial class SettingsService : ObservableObject
 #if !UNPKG
 private static readonly ApplicationDataContainer Settings = ApplicationData.Current.LocalSettings;
 #else
-	public static FauxSettings Settings = new();
-
-	public class FauxSettings {
-		public FauxSettings Current => this;
-		public FauxSettings InstalledLocation => this;
-		public string Path => System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-
-		public class FauxValues {
-			public Dictionary<string, object> dict = new();
-			public object this[string key] {
-				get {
-					if (dict.TryGetValue(key, out var value))
-						return value;
-					dict.Add(key, null);
-					return null;
-				}
-				set { dict[key] = value; }
-			}
-		}
-		public FauxValues Values = new();
-	}
+	internal static Classes.FauxSettings Settings = new();
 
 #endif
 

--- a/UnitedSets/UnitedSets.csproj
+++ b/UnitedSets/UnitedSets.csproj
@@ -21,7 +21,8 @@
 		<AppxBundle>Never</AppxBundle>
 		<HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
 		<Configurations>Debug;Release;DebugUnpackaged</Configurations>
-		<LangVersion>preview</LangVersion>
+		<ApplicationIcon>Assets\UnitedSets.ico</ApplicationIcon>
+		<LangVersion>preview</LangVersion>				
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Remove="AppPackages\**" />


### PR DESCRIPTION
Ability to save out the settings to disk and read them on launch. Tries using a file in the exe dir if that isn't writable uses a file in AppData.

Wanted to add an exception to the app if you started the unpackaged version without changing the config to DebugUnpackaged but I didn't see an easy way to do so.  WinUI writes a lot of code in for the actual Program.cs main() func, which we could clone and then add a message about, but that seemed fragile.

