### PR TITLE
Large encapsulation changes for MainWindow logic and HwndHost wrapped in our class

### DIFF
--- a/UnitedSets/Classes/Cell.APIs.cs
+++ b/UnitedSets/Classes/Cell.APIs.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
 using System.Linq;
 using System;
@@ -9,11 +9,11 @@ using UnitedSets.Windows;
 namespace UnitedSets.Classes;
 partial class Cell
 {
-    public void RegisterWindow(Window Window)
+    public void RegisterWindow(OurHwndHost host)
     {
         // There MUST BE NO SUBCELL AND CURRNETCELL
         if (!Empty) throw new InvalidOperationException();
-        CurrentCell = new(MainWindow, Window);
+        CurrentCell = host;
     }
 
     public void SplitHorizontally(int Amount)
@@ -33,20 +33,20 @@ partial class Cell
     
     Cell[] CraeteNCells(int Amount)
     {
-        return (from _ in 0..Amount select new Cell(MainWindow, null, null, default)).ToArray();
+        return (from _ in 0..Amount select new Cell(null, null, default)).ToArray();
     }
 
-    public Cell DeepClone(MainWindow NewWindow)
-    {
-        Cell[]? newSubCells =
-            SubCells is null ? null :
-            (from x in SubCells select x.DeepClone(NewWindow)).ToArray();
-        HwndHost? hwndHost =
-            CurrentCell is null ? null
-            : new HwndHost(NewWindow, CurrentCell.HostedWindow);
-        Cell cell = new(NewWindow, hwndHost, newSubCells, Orientation);
-        return cell;
-    }
+    //public Cell DeepClone(MainWindow NewWindow)
+    //{
+    //    Cell[]? newSubCells =
+    //        SubCells is null ? null :
+    //        (from x in SubCells select x.DeepClone(NewWindow)).ToArray();
+    //    HwndHost? hwndHost =
+    //        CurrentCell is null ? null
+    //        : new HwndHost(NewWindow, CurrentCell.HostedWindow);
+    //    Cell cell = new(NewWindow, hwndHost, newSubCells, Orientation);
+    //    return cell;
+    //}
 
     public (Cell?, double renamining) GetChildFromPosition(double normalizedPosition)
     {

--- a/UnitedSets/Classes/Cell.Property.Callback.cs
+++ b/UnitedSets/Classes/Cell.Property.Callback.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
 using EasyCSharp;
 using WinUI3HwndHostPlus;
@@ -15,7 +15,9 @@ partial class Cell
             {
                 CurrentCell = null;
             };
-            _CurrentCell.IsWindowVisible = IsVisible;
+			_CurrentCell.SetVisible(IsVisible, false);
+			
+
         }
     }
 
@@ -31,7 +33,10 @@ partial class Cell
         if (_SubCells is not null)
             foreach (var cell in _SubCells)
                 cell.IsParentVisible = IsVisible;
-        if (CurrentCell is HwndHost hwndHost) hwndHost.IsWindowVisible = IsVisible;
-        else PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsVisible)));
-    }
+		if (CurrentCell != null)
+			CurrentCell.SetVisible(IsVisible); 
+		else
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsVisible)));
+
+	}
 }

--- a/UnitedSets/Classes/Cell.Property.cs
+++ b/UnitedSets/Classes/Cell.Property.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
 using EasyCSharp;
 using WinUI3HwndHostPlus;
@@ -7,10 +7,9 @@ using UnitedSets.Windows;
 namespace UnitedSets.Classes;
 partial class Cell
 {
-    public MainWindow MainWindow { get; }
 
     [AutoNotifyProperty(OnChanged = nameof(OnCurrentCellChanged))]
-    HwndHost? _CurrentCell;
+    OurHwndHost? _CurrentCell;
 
     [AutoNotifyProperty(OnChanged = nameof(OnSubCellsUpdate))]
     Cell[]? _SubCells;

--- a/UnitedSets/Classes/Cell.UI.Events.cs
+++ b/UnitedSets/Classes/Cell.UI.Events.cs
@@ -22,16 +22,18 @@ partial class Cell
     public void OnItemDrop(DragEventArgs e)
     {
         // There MUST BE NO SUBCELL AND CURRNETCELL
-		if (!Empty || !e.DataView.Properties.TryGetValue(MainWindow.UnitedSetsTabWindowDragProperty, out var _a) || _a is long hwnd == false)
+        if (!Empty || !e.DataView.Properties.TryGetValue(MainWindow.UnitedSetsTabWindowDragProperty, out var _a) || _a is long hwnd == false)
 			return;
-
-		var window = Window.FromWindowHandle((nint)hwnd);
-		var ret = PInvoke.SendMessage(window.Owner, MainWindow.UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
-		RegisterWindow(window);
+		ValidDrop?.Invoke(this, new ValidItemDropArgs(hwnd));
 
     }
+	public class ValidItemDropArgs : EventArgs {
+		public ValidItemDropArgs(long HwndId) => this.HwndId = HwndId;
+		public long HwndId;
+	}
+	public static event EventHandler<ValidItemDropArgs>? ValidDrop;
 
-    [Event(typeof(RoutedEventHandler), Name = "AddCellAddCountClickEv")]
+	[Event(typeof(RoutedEventHandler), Name = "AddCellAddCountClickEv")]
     public void AddCellAddCount()
     {
         CellAddCount += 1;

--- a/UnitedSets/Classes/Cell.cs
+++ b/UnitedSets/Classes/Cell.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
 using System.Linq;
 using System;
@@ -9,9 +9,8 @@ using UnitedSets.Windows;
 namespace UnitedSets.Classes;
 public partial class Cell : INotifyPropertyChanged
 {
-    public Cell(MainWindow MainWindow, HwndHost? CurrentCell, Cell[]? SubCells, Orientation Orientation)
+    public Cell(OurHwndHost? CurrentCell, Cell[]? SubCells, Orientation Orientation)
     {
-        this.MainWindow = MainWindow;
         _CurrentCell = CurrentCell;
         _SubCells = SubCells;
         _Orientation = Orientation;

--- a/UnitedSets/Classes/OurHwndHost.cs
+++ b/UnitedSets/Classes/OurHwndHost.cs
@@ -1,0 +1,116 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using UnitedSets.Classes.Tabs;
+using WinUI3HwndHostPlus;
+using WindowEx = WinWrapper.Window;
+
+using EasyCSharp;
+
+namespace UnitedSets.Classes {
+	public interface IHwndHostParent {
+		TabBase Tab { get; }
+	}
+	public partial class OurHwndHost : INotifyPropertyChanged {
+		public event PropertyChangedEventHandler? PropertyChanged;
+		protected HwndHost host;
+
+		public HwndHost HwndHostForRenderBinding => host;
+		public IHwndHostParent parent { get; }
+
+		public OurHwndHost(IHwndHostParent parent, Window XAMLWindow, WindowEx WindowToHost) {
+			host = new HwndHost(XAMLWindow, WindowToHost);
+			this.parent = parent;
+			host.Closed += Host_Closed;
+		}
+
+		public string GetTitle() => host.HostedWindow.TitleText;
+		public string? GetOwnerProcessModuleFilename() {
+			var FileName = host.HostedWindow.OwnerProcess.GetDotNetProcess.MainModule?.FileName;
+			if (FileName == @"C:\WINDOWS\system32\ApplicationFrameHost.exe") {
+				var child = host.HostedWindow.Children.FirstOrDefault(x =>
+					x.ClassName is "Windows.UI.Core.CoreWindow", host.HostedWindow);
+				FileName = child.OwnerProcess.GetDotNetProcess.MainModule?.FileName;
+			}
+			return FileName;
+		}
+
+		[AutoNotifyProperty]
+		int _CropTop;
+		private void CropTopChanged() => host.CropTop = _CropTop;
+		[AutoNotifyProperty]
+		private int _CropLeft;
+		private void CropLeftChanged() => host.CropLeft = _CropLeft;
+		[AutoNotifyProperty]
+		private int _CropRight;
+		private void CropBRightChanged() => host.CropRight = _CropRight;
+		[AutoNotifyProperty]
+		private int _CropBottom;
+		private void CropBottomChanged() => host.CropBottom = _CropBottom;
+
+		[AutoNotifyProperty(OnChanged=nameof(ActivateCropChanged))]
+		private bool _ActivateCrop;
+		private void ActivateCropChanged() => host.ActivateCrop = _ActivateCrop;
+
+		[AutoNotifyProperty(OnChanged =nameof(BorderlessWindowChanged))]
+		private bool _BorderlessWindow;
+		private void BorderlessWindowChanged() => host.BorderlessWindow = _BorderlessWindow;
+
+		private void RaisePropertyChanged(params string[] properties) {
+			foreach (var prop in properties)
+				PropertyChanged?.Invoke(this, new(prop));
+		}
+		public void ClearCrop() {
+			_CropTop = _CropBottom = _CropLeft = _CropRight = 0;
+			RaisePropertyChanged(nameof(_CropTop),nameof(_CropBottom),nameof(_CropLeft),nameof(_CropRight));
+			host.ClearCrop();
+			host.Loaded += Host_Loaded;
+		}
+
+		private void Host_Loaded(object sender, RoutedEventArgs e) {
+			OurDbg.Log("HostLoaded");
+		}
+
+		public async Task DetachAndDispose() {
+			await host.DetachAndDispose();
+			Detached?.Invoke(this, EventArgs.Empty);
+		}
+		public bool NoMoving => host.NoMovingMode;
+		public bool IsOwnerSetSuccessful => host.IsOwnerSetSuccessful;
+		public async Task Close() {
+			_clean_close = true;
+			await host.HostedWindow.TryCloseAsync();
+			_closed = true;
+			Closed?.Invoke(this, EventArgs.Empty);
+		}
+		public bool IsWindowStillValid() {
+			if (host.HostedWindow.IsValid)
+				return true;
+			if (!_closed)
+				Host_Closed();
+			return false;
+		}
+		private void Host_Closed() {//this should only get called if the window handle is no longer valid or we called Close
+			if (_closed)
+                System.Diagnostics.Debug.WriteLine("OurHwndHost::Host_Closed: Already closed??");
+			if (! _clean_close)
+				Closed?.Invoke(this, EventArgs.Empty);
+			_closed = true;
+		}
+		private bool _closed;
+		private bool _clean_close;
+		public event EventHandler Closed;
+		public event EventHandler Detached;
+		public void SetBorderless(bool borderless) =>BorderlessWindow = borderless;
+
+		public void SetVisible(bool visible, bool FocusOnVisible=true) {
+			host.IsWindowVisible = visible;
+			if (visible && FocusOnVisible)
+				host.FocusWindow();
+		}
+		
+	}
+}

--- a/UnitedSets/Classes/Tabs/CellTab.cs
+++ b/UnitedSets/Classes/Tabs/CellTab.cs
@@ -1,25 +1,22 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using UnitedSets.Windows;
 
 namespace UnitedSets.Classes.Tabs;
 
-public partial class CellTab : TabBase
-{
-    readonly MainWindow MainWindow;
-    
-    public CellTab(MainWindow MainWindow, bool IsTabSwitcherVisibile)
+public partial class CellTab : TabBase, IHwndHostParent {
+
+	TabBase IHwndHostParent.Tab => this;
+	public CellTab(bool IsTabSwitcherVisibile)
         : this(
-              MainWindow,
-              new(MainWindow, null, null, Orientation.Horizontal),
+              new(null, null, Orientation.Horizontal),
               IsTabSwitcherVisibile
         )
     {
     }
     
-    protected CellTab(MainWindow MainWindow, Cell Cell, bool IsTabSwitcherVisibile)
-        : base(MainWindow.TabView, IsTabSwitcherVisibile)
+    protected CellTab(Cell Cell, bool IsTabSwitcherVisibile)
+        : base(IsTabSwitcherVisibile)
     {
-        this.MainWindow = MainWindow;
         _MainCell = Cell;
     }
 }

--- a/UnitedSets/Classes/Tabs/HwndHostTab.Implement.APIs.cs
+++ b/UnitedSets/Classes/Tabs/HwndHostTab.Implement.APIs.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Drawing;
 using System.Threading.Tasks;
@@ -27,9 +27,10 @@ partial class HwndHostTab
     public override async void DetachAndDispose(bool JumpToCursor)
     {
         var Window = this.Window;
-        await HwndHost.DetachAndDispose();
+		var NoMovingMode = HwndHost.NoMoving;
+		await HwndHost.DetachAndDispose();
         PInvoke.GetCursorPos(out var CursorPos);
-        if (JumpToCursor && !HwndHost.NoMovingMode)
+        if (JumpToCursor && !NoMovingMode)
             Window.Location = new Point(CursorPos.X - 100, CursorPos.Y - 30);
         Window.Focus();
         Window.Redraw();
@@ -38,17 +39,10 @@ partial class HwndHostTab
     }
     public override void Focus()
     {
-        HwndHost.IsWindowVisible = true;
-        HwndHost.FocusWindow();
+		HwndHost.SetVisible(true);
     }
-    protected override async void OnDoubleClick()
+    protected override void OnDoubleClick()
     {
-        var flyout = new LeftFlyout(
-            WindowEx.FromWindowHandle(MainWindow.GetWindowHandle()),
-            new BasicTabFlyoutModule(this),
-            new ModifyWindowFlyoutModule(HwndHost)
-        );
-        await flyout.ShowAsync();
-        flyout.Close();
+		DoShowFlyout(new ModifyWindowFlyoutModule(HwndHost));
     }
 }

--- a/UnitedSets/Classes/Tabs/HwndHostTab.Property.cs
+++ b/UnitedSets/Classes/Tabs/HwndHostTab.Property.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Drawing;
 using System.Threading.Tasks;
@@ -21,20 +21,18 @@ namespace UnitedSets.Classes.Tabs;
 
 partial class HwndHostTab
 {
-    readonly MainWindow MainWindow;
     public readonly WindowEx Window;
-    public event Action Closed;
 
-    public HwndHost HwndHost { get; }
+    public OurHwndHost HwndHost { get; }
 
     [Property(OverrideKeyword = true, OnChanged = nameof(OnSelectedChanged))]
     bool _Selected;
-    void OnSelectedChanged()
+    async void OnSelectedChanged()
     {
-        HwndHost.IsWindowVisible = _Selected;
-        if (_Selected) HwndHost.FocusWindow();
-        InvokePropertyChanged(nameof(Selected));
-    }
+		HwndHost.SetVisible(_Selected);
+		InvokePropertyChanged(nameof(Selected));
+		
+	}
 
     
 }

--- a/UnitedSets/Classes/Tabs/TabBase.Events.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.Events.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using EasyCSharp;
 using Windows.Foundation;
 
@@ -9,7 +9,7 @@ partial class TabBase
     [Event(typeof(TypedEventHandler<TabViewItem, TabViewTabCloseRequestedEventArgs>), Visibility = GeneratorVisibility.Public, Name = "TabCloseRequestedEv")]
     void TabCloseRequested(TabViewItem sender)
     {
-        ParentTabView.SelectedItem = sender;
+		DoShowTab();
         if (Settings.ExitOnClose)
             _ = TryCloseAsync();
         else

--- a/UnitedSets/Classes/Tabs/TabBase.Property.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.Property.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
 using EasyCSharp;
 
@@ -7,8 +7,6 @@ namespace UnitedSets.Classes.Tabs;
 partial class TabBase
 {
     public bool IsSwitcherVisible { get; }
-
-    public TabView ParentTabView { get; }
 
     public string Title => string.IsNullOrWhiteSpace(CustomTitle) ? DefaultTitle : CustomTitle;
 

--- a/UnitedSets/Classes/Tabs/TabBase.Static.Loop.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.Static.Loop.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -6,7 +7,8 @@ namespace UnitedSets.Classes.Tabs;
 
 partial class TabBase
 {
-    static void StaticUpdateStatusThreadLoop()
+
+	static void StaticUpdateStatusThreadLoop()
     {
         while (true)
         {
@@ -16,10 +18,12 @@ partial class TabBase
 
             try
             {
-                foreach (var tab in AllTabs.ToArray())
+				foreach (var tab in AllTabs.ToArray())
                 {
-                    if (tab.IsDisposed) AllTabs.Remove(tab);
-                    else tab.UpdateStatusLoop();
+					if (tab.IsDisposed)
+						AllTabs.Remove(tab);
+					else
+						tab.UpdateStatusLoop();
                 }
                 OnUpdateStatusLoopComplete?.Invoke();
             }

--- a/UnitedSets/Classes/Tabs/TabBase.Static.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.Static.cs
@@ -14,7 +14,7 @@ partial class TabBase
     public readonly static List<Window> MainWindows = new();
     public static event Action? OnUpdateStatusLoopComplete;
     static readonly SynchronizedCollection<TabBase> AllTabs = new();
-    static readonly WindowClass UnitedSetsSwitcherWindowClass;
+    //static readonly WindowClass UnitedSetsSwitcherWindowClass;
 
     static readonly SettingsService Settings
         = App.Current.Services.GetService<SettingsService>() ?? throw new InvalidOperationException("Settings Init Failed");

--- a/UnitedSets/Classes/Tabs/TabBase.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.cs
@@ -1,15 +1,34 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace UnitedSets.Classes.Tabs;
 
 public abstract partial class TabBase : INotifyPropertyChanged
 {
-    public TabBase(TabView Parent, bool IsSwitcherVisible)
+    public TabBase(bool IsSwitcherVisible)
     {
-        AllTabs.Add(this);
-        ParentTabView = Parent;
+		AllTabs.Add(this);
         this.IsSwitcherVisible = IsSwitcherVisible;
         InitSwitcher();
     }
+	public event EventHandler RemoveTab;
+	public event EventHandler ShowTab;
+	protected virtual void DoShowTab() {
+		this.ShowTab?.Invoke(this, EventArgs.Empty);
+	}
+	public event EventHandler<ShowFlyoutEventArgs> ShowFlyout;
+	public class ShowFlyoutEventArgs : EventArgs {
+		public ShowFlyoutEventArgs(UIElement element) {
+			this.element = element;
+		}
+		public UIElement element;
+	}
+	protected virtual void DoShowFlyout(UIElement element) {
+		var args = new ShowFlyoutEventArgs(element);
+		ShowFlyout?.Invoke(this, args);
+	}
+	protected virtual void DoRemoveTab() => RemoveTab?.Invoke(this, EventArgs.Empty);
 }

--- a/UnitedSets/Controls/CellVisualizer.xaml
+++ b/UnitedSets/Controls/CellVisualizer.xaml
@@ -1,4 +1,4 @@
-﻿<ContentPresenter
+<ContentPresenter
     x:Class="UnitedSets.Controls.CellVisualizer"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -121,7 +121,7 @@
             </Grid>
         </DataTemplate>
         <DataTemplate x:Name="WindowCellDataTemplate" x:DataType="class:Cell">
-            <ContentPresenter Content="{x:Bind CurrentCell}" Margin="10"/>
+            <ContentPresenter Content="{x:Bind CurrentCell.HwndHostForRenderBinding}" Margin="10"/>
         </DataTemplate>
     </ContentPresenter.Resources>
 </ContentPresenter>

--- a/UnitedSets/Templates/TabDataTemplate.xaml
+++ b/UnitedSets/Templates/TabDataTemplate.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     x:Class="UnitedSets.Templates.TabDataTemplate"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,7 +7,7 @@
     xmlns:tabs="using:UnitedSets.Classes.Tabs"
     xmlns:controls="using:UnitedSets.Controls">
     <DataTemplate x:Name="SingleTabDataTemplate" x:FieldModifier="Public" x:DataType="tabs:HwndHostTab">
-        <Border Child="{x:Bind HwndHost}"/>
+		<Border Child="{x:Bind HwndHost.HwndHostForRenderBinding}"/>
         <!--Recreating HwndHost is expensive-->
     </DataTemplate>
     <DataTemplate x:Name="CellTabDataTemplate" x:FieldModifier="Public" x:DataType="tabs:CellTab">

--- a/UnitedSets/Windows/Flyout/Modules/MainWindowMenuFlyoutModule.xaml.cs
+++ b/UnitedSets/Windows/Flyout/Modules/MainWindowMenuFlyoutModule.xaml.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using UnitedSets.Classes.Tabs;
 using UnitedSets.Windows;
 using UnitedSets.Windows.Flyout;
+using CommunityToolkit.WinUI;
 
 namespace UnitedSets.Windows.Flyout.Modules;
 
@@ -40,11 +41,11 @@ public sealed partial class MainWindowMenuFlyoutModule : Grid, IWindowFlyoutModu
     [Event(typeof(RoutedEventHandler))]
     void SetTabsAside()
     {
-        var tabs = MainWindow.Tabs;
+        
         var tabgroup = new TabGroup($"Tabs {DateTime.Now:hh:mm:ss}");
-        foreach (var tab in tabs)
+		var tabs = MainWindow.GetTabsAndClear();
+		foreach (var tab in tabs)
             tabgroup.Tabs.Add(tab);
-        MainWindow.Tabs.Clear();
         MainWindow.HiddenTabs.Add(tabgroup);
     }
     [Event(typeof(SelectionChangedEventHandler))]
@@ -57,7 +58,7 @@ public sealed partial class MainWindowMenuFlyoutModule : Grid, IWindowFlyoutModu
     void ShowOnWindow([CastFrom(typeof(object))] FrameworkElement sender)
     {
         if (sender.Tag is not TabBase tab) return;
-        MainWindow.Tabs.Add(tab);
+        MainWindow.AddTab(tab);
         if (TabGroupListView.SelectedItem is TabGroup TabGroup)
             TabGroup.Tabs.Remove(tab);
     }
@@ -68,7 +69,7 @@ public sealed partial class MainWindowMenuFlyoutModule : Grid, IWindowFlyoutModu
         MainWindow.HiddenTabs.Remove(tabgroup);
         foreach (var tab in tabgroup.Tabs)
         {
-            MainWindow.Tabs.Add(tab);
+            MainWindow.AddTab(tab);
         }
     }
     [Event(typeof(RoutedEventHandler))]
@@ -178,54 +179,42 @@ public sealed partial class MainWindowMenuFlyoutModule : Grid, IWindowFlyoutModu
     {
         const string UnitedSetsTabWindowDragProperty = MainWindow.UnitedSetsTabWindowDragProperty;
 
-		if (e.DataView.Properties.TryGetValue(UnitedSetsTabWindowDragProperty, out var _a) && _a is long a)
-		{
-			var pt = e.GetPosition(TabListView);
-            if (TabGroupListView.SelectedIndex is -1) return;
-            var tabgroup = MainWindow.HiddenTabs[TabGroupListView.SelectedIndex];
-            var window = Window.FromWindowHandle((nint)a);
-            var finalIdx = (
-                from index in Enumerable.Range(0, tabgroup.Tabs.Count)
-                let ele = TabListView.ContainerFromIndex(index) as UIElement
-                let posele = ele.TransformToVisual(TabListView).TransformPoint(default)
-                let size = ele.ActualSize
-                let IsMoreThanTopLeft = pt.X >= posele.X && pt.Y >= posele.Y
-                let IsLessThanBotRigh = pt.X <= posele.X + size.X && pt.Y <= posele.Y + size.Y
-                where IsMoreThanTopLeft && IsLessThanBotRigh
-                select (int?)index
-            ).FirstOrDefault();
-            TabBase? tabValue;
-            if (window.Owner != MainWindow.WindowEx)
-            {
-                var ret = PInvoke.SendMessage(window.Owner, MainWindow.UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
-                tabValue = new HwndHostTab(MainWindow, window, MainWindow.IsAltTabVisible);
-            } else
-            {
-                tabValue = null;
-                foreach (var tab in MainWindow.Tabs)
-                {
-                    if (tab.Windows.Contains(window))
-                    {
-                        tabValue = tab;
-                        MainWindow.Tabs.Remove(tab);
-                    }
-                }
-                foreach (var tg in MainWindow.HiddenTabs)
-                {
-                    foreach (var tab in tg.Tabs)
-                    {
-                        if (tab.Windows.Contains(window))
-                        {
-                            tabValue = tab;
-                            tg.Tabs.Remove(tab);
-                        }
-                    }
-                }
-            }
-            if (tabValue is null) return;
-            if (finalIdx.HasValue)
-                tabgroup.Tabs.Insert(finalIdx.Value, tabValue);
-            else tabgroup.Tabs.Add(tabValue);
-        }
-    }
+		if (!e.DataView.Properties.TryGetValue(UnitedSetsTabWindowDragProperty, out var _a) || _a is long a == false)
+			return;
+		
+		var pt = e.GetPosition(TabListView);
+        if (TabGroupListView.SelectedIndex is -1)
+			return;
+        var tabgroup = MainWindow.HiddenTabs[TabGroupListView.SelectedIndex];
+        var window = Window.FromWindowHandle((nint)a);
+        var finalIdx = (
+            from index in Enumerable.Range(0, tabgroup.Tabs.Count)
+            let ele = TabListView.ContainerFromIndex(index) as UIElement
+            let posele = ele.TransformToVisual(TabListView).TransformPoint(default)
+            let size = ele.ActualSize
+            let IsMoreThanTopLeft = pt.X >= posele.X && pt.Y >= posele.Y
+            let IsLessThanBotRigh = pt.X <= posele.X + size.X && pt.Y <= posele.Y + size.Y
+            where IsMoreThanTopLeft && IsLessThanBotRigh
+            select (int?)index
+        ).FirstOrDefault();
+        TabBase? tabValue;
+		if (window.Owner != MainWindow.WindowEx) {
+			var ret = PInvoke.SendMessage(window.Owner, MainWindow.UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
+			tabValue = MainWindow.JustCreateTab(window);
+		} else {
+			tabValue = MainWindow.FindTabByWindow(window);
+			if (tabValue != null)
+				MainWindow.RemoveTab(tabValue);
+
+			var hiddenResult = MainWindow.FindHiddenTabByWindow(window);
+			if (hiddenResult.tab != null) {
+				tabValue = hiddenResult.tab;
+				hiddenResult.group!.Tabs.Remove(tabValue);
+			}
+		}
+		if (tabValue is null) return;
+		if (finalIdx.HasValue)
+			tabgroup.Tabs.Insert(finalIdx.Value, tabValue);
+		else tabgroup.Tabs.Add(tabValue);
+	}
 }

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/MultiWindowModifyFlyoutModule.xaml.cs
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/MultiWindowModifyFlyoutModule.xaml.cs
@@ -1,4 +1,4 @@
-﻿using EasyCSharp;
+using EasyCSharp;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using UnitedSets.Classes;
@@ -7,16 +7,16 @@ namespace UnitedSets.Windows.Flyout.Modules;
 
 public sealed partial class MultiWindowModifyFlyoutModule
 {
-    public MultiWindowModifyFlyoutModule(HwndHost[] HwndHosts)
+    public MultiWindowModifyFlyoutModule(OurHwndHost[] HwndHosts)
     {
         this.HwndHosts = HwndHosts;
         InitializeComponent();
         foreach (var hwndhost in HwndHosts)
         {
-            HwndHostSelector.Items.Add(hwndhost.HostedWindow.TitleText);
+            HwndHostSelector.Items.Add(hwndhost.GetTitle());
         }
     }
-    readonly HwndHost[] HwndHosts;
+    readonly OurHwndHost[] HwndHosts;
 
     [Event(typeof(SelectionChangedEventHandler))]
     void HwndHostSelector_SelectionChanged()

--- a/UnitedSets/Windows/MainWindow.xaml.API.cs
+++ b/UnitedSets/Windows/MainWindow.xaml.API.cs
@@ -1,4 +1,4 @@
-﻿using EasyCSharp;
+using EasyCSharp;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Controls;
 using System.Collections.ObjectModel;
@@ -30,34 +30,41 @@ using System.Text.RegularExpressions;
 using Windows.Foundation;
 using WinUI3HwndHostPlus;
 using UnitedSets.Classes.Tabs;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+using UnitedSets.Windows.Flyout.Modules;
+using UnitedSets.Windows.Flyout;
 
 namespace UnitedSets.Windows;
 
 public sealed partial class MainWindow : INotifyPropertyChanged
 {
-    void AddTab(WindowEx newWindow, int? index = null)
+    public void AddTab(WindowEx newWindow, int? index = null)
     {
-        if (!newWindow.IsValid)
-            return;
-        newWindow = newWindow.Root;
-        if (newWindow.Handle == IntPtr.Zero)
-            return;
-        if (newWindow.Handle == AddTabFlyout.GetWindowHandle())
-            return;
-        if (newWindow.Handle == WindowEx.Handle)
-            return;
-        if (HwndHost.ShouldBeBlacklisted(newWindow))
-            return;
-        // Check if United Sets has owner (United Sets in United Sets)
-        if (WindowEx.Root.Children.Any(x => x == newWindow))
-            return;
-        if (Tabs.Any(x => x.Windows.Any(y => y == newWindow)))
-            return;
-        var newTab = new HwndHostTab(this, newWindow, IsAltTabVisible);
-        if (index.HasValue)
-            Tabs.Insert(index.Value, newTab);
-        else
-            Tabs.Add(newTab);
-        TabView.SelectedItem = newTab;
+		var newTab = JustCreateTab(newWindow);
+		if (newTab == null)
+			return;
+		AddTab(newTab, index);
+		TabView.SelectedItem = newTab;
     }
+
+	
+	public HwndHostTab? JustCreateTab(WindowEx newWindow) {
+		if (!newWindow.IsValid)
+			return null;
+		newWindow = newWindow.Root;
+		if (newWindow.Handle == IntPtr.Zero)
+			return null;
+		if (newWindow.Handle == AddTabFlyout.GetWindowHandle())
+			return null;
+		if (newWindow.Handle == WindowEx.Handle)
+			return null;
+		if (HwndHost.ShouldBeBlacklisted(newWindow))
+			return null;
+		// Check if United Sets has owner (United Sets in United Sets)
+		if (WindowEx.Root.Children.Any(x => x == newWindow))
+			return null;
+		if (Tabs.ToArray().Any(x => x.Windows.Any(y => y == newWindow)))
+			return null;
+		return new HwndHostTab((IHwndHostParent tab) => new OurHwndHost(tab, this, newWindow),DispatcherQueue, newWindow, IsAltTabVisible);
+	}
 }

--- a/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
+++ b/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
@@ -33,6 +33,7 @@ using UnitedSets.Windows.Flyout;
 using UnitedSets.Classes.Tabs;
 using UnitedSets.Windows.Flyout.Modules;
 using Microsoft.VisualBasic.Logging;
+using CommunityToolkit.WinUI;
 
 namespace UnitedSets.Windows;
 
@@ -64,9 +65,22 @@ public sealed partial class MainWindow : INotifyPropertyChanged
 
         if (Keyboard.IsShiftDown)
             WindowEx.SetAppId($"UnitedSets {WindowEx.Handle}");
+		Cell.ValidDrop += Cell_ValidDrop;
     }
 
-    [Event(typeof(TypedEventHandler<FrameworkElement, EffectiveViewportChangedEventArgs>))]
+	private void Cell_ValidDrop(object? sender, Cell.ValidItemDropArgs e) {
+		var cell = sender as Cell;
+		if (cell == null)
+			throw new Exception("Only cells should be generating this event");
+		var window = WinWrapper.Window.FromWindowHandle((nint)e.HwndId);
+		var ret = PInvoke.SendMessage(window.Owner, MainWindow.UnitedSetCommunicationChangeWindowOwnership, new(), new(window));
+		var tab = Tabs.ToArray().OfType<CellTab>().FirstOrDefault(tab => tab._MainCell.AllSubCells.Any(c=>c == cell));
+		if (tab == null)
+			throw new Exception("Cannot find the tab parent of that cell");
+		cell.RegisterWindow(new OurHwndHost(tab,this,window));
+	}
+
+	[Event(typeof(TypedEventHandler<FrameworkElement, EffectiveViewportChangedEventArgs>))]
     void OnCustomDragRegionUpdatorCalled()
     {
         CustomDragRegion.Width = CustomDragRegionUpdator.ActualWidth - 10;
@@ -92,7 +106,7 @@ public sealed partial class MainWindow : INotifyPropertyChanged
         if (e.Message.MessageId == UnitedSetCommunicationChangeWindowOwnership)
         {
             var winPtr = e.Message.LParam;
-            if (Tabs.FirstOrDefault(x => x.Windows.Any(y => y == winPtr)) is TabBase Tab)
+            if (Tabs.ToArray().FirstOrDefault(x => x.Windows.Any(y => y == winPtr)) is TabBase Tab)
             {
                 Tab.DetachAndDispose(false);
                 e.Result = 1;
@@ -108,8 +122,8 @@ public sealed partial class MainWindow : INotifyPropertyChanged
     {
         if (Keyboard.IsShiftDown)
         {
-            var newTab = new CellTab(this, IsAltTabVisible);
-            Tabs.Add(newTab);
+            var newTab = new CellTab(IsAltTabVisible);
+			AddTab(newTab);
             TabView.SelectedItem = newTab;
         }
         else
@@ -260,8 +274,8 @@ public sealed partial class MainWindow : INotifyPropertyChanged
                 // Release all windows
                 while (Tabs.Count > 0)
                 {
-                    var Tab = Tabs[0];
-                    Tabs.RemoveAt(0);
+                    var Tab = Tabs.First();
+					RemoveTab(Tab);
                     Tab.DetachAndDispose(JumpToCursor: false);
                 }
 				await TimerStop();
@@ -318,4 +332,30 @@ public sealed partial class MainWindow : INotifyPropertyChanged
     {
         DispatcherQueue.TryEnqueue(() => TabViewSizer.InvalidateArrange());
     }
+	private async void TabRemoveRequest(object? sender, EventArgs e) {
+		var tab = sender as TabBase;
+		if (tab == null)
+			throw new ArgumentException();
+		await DispatcherQueue.EnqueueAsync(() => RemoveTab(tab));
+		UnwireTabEvents(tab);
+	}
+	private async void TabShowFlyoutRequest(object? sender, TabBase.ShowFlyoutEventArgs e) {
+		var tab = sender as TabBase;
+		if (tab == null)
+			throw new ArgumentException();
+		var flyout = new LeftFlyout(
+		WindowEx.FromWindowHandle(WindowNative.GetWindowHandle(this)),
+			new BasicTabFlyoutModule(tab),
+				e.element
+		);
+		await flyout.ShowAsync();
+		flyout.Close();
+
+	}
+	private void TabShowRequest(object? sender, EventArgs e) {
+		var tab = sender as TabBase;
+		if (tab == null)
+			throw new ArgumentException();
+		TabView.SelectedItem = tab;
+	}
 }

--- a/WinUI3HwndHostPlus/HwndHost.Static.cs
+++ b/WinUI3HwndHostPlus/HwndHost.Static.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.UI.Dispatching;
 using System.Threading;
 using WindowEx = WinWrapper.Window;
+using System.Linq;
 
 namespace WinUI3HwndHostPlus;
 
@@ -29,7 +30,7 @@ partial class HwndHost
             timer.Interval = TimeSpan.FromMilliseconds(500);
             timer.Tick += delegate
             {
-                foreach (var HwndHost in HwndHosts)
+                foreach (var HwndHost in HwndHosts.ToArray())
                 {
                     var Pt = HwndHost.TransformToVisual(HwndHost.XAMLWindow.Content).TransformPoint(
                         new Windows.Foundation.Point(0, 0)
@@ -52,7 +53,7 @@ partial class HwndHost
     static void OnHwndHostLoopCalled()
     {
     Start:
-        foreach (var HwndHost in ActiveHwndHosts)
+        foreach (var HwndHost in ActiveHwndHosts.ToArray())
         {
             if (HwndHost.IsDisposed)
             {


### PR DESCRIPTION
This is a fairly large refectoring to try and improve encapsulation between classes.   Rather than having duplicate logic in multiple places, have other classes modifying mainwindow items, have each class handle itself (mostly).  

I am not sure how I feel about the static event on Cell.  It was an easy hack, at the same time I am not sure there is really a reason to not have static TabBase events but this mostly seems appropriate.   

It introduces a new OurHwndHost class that wraps the old HwndHost completely.  Insulating it so we have one chokepoint that all commands must flow through.  This does something else in it allows the properties like crop, borderless, activecrop are all cached in that class so even if HwndHost is disposed we can still access them.  In addition when we detach we reset all these things, but this class retains the original values.

Encapsulation also makes sure that every time we detach a tab, or add a tab all the correct operations are performed.