### PR TITLE
Bandaid fix for when windows seem to go invisible/minimized

### DIFF
--- a/UnitedSets/Classes/OurHwndHost.cs
+++ b/UnitedSets/Classes/OurHwndHost.cs
@@ -106,11 +106,28 @@ namespace UnitedSets.Classes {
 		public event EventHandler Detached;
 		public void SetBorderless(bool borderless) =>BorderlessWindow = borderless;
 
-		public void SetVisible(bool visible, bool FocusOnVisible=true) {
+
+		private object CurFix;
+		private async void DelaySizeFix() {
+			var us = CurFix = new();
+			await Task.Delay(700);
+			if (us != CurFix)
+				return;
+			if (host.MayBeSizeBug) {
+				System.Diagnostics.Debug.WriteLine($"Warning for the host: {host} had to fix the size as think we had a size bug is win visible: {host.Visibility}.");
+				host.FixSizeBug();
+			}
+		}
+		public void SetVisible(bool visible, bool FocusOnVisible = true) {
 			host.IsWindowVisible = visible;
 			if (visible && FocusOnVisible)
 				host.FocusWindow();
+			if (visible) {
+				if (host.MayBeSizeBug)
+					DelaySizeFix();
+
+			}
 		}
-		
+
 	}
 }

--- a/WinUI3HwndHostPlus/HwndHost.UpdateLoop.cs
+++ b/WinUI3HwndHostPlus/HwndHost.UpdateLoop.cs
@@ -13,6 +13,8 @@ partial class HwndHost
 		CropLeft = CropRight = CropBottom = CropTop = 0;
 		await _HostedWindow.SetRegionAsync(null);//could do initial region as well
 	}
+	public void FixSizeBug() => _HostedWindow.Restore();
+	public bool MayBeSizeBug =>  _CacheWidth == 0 && _CacheHeight ==0 && ! IsDisposed && _HostedWindow.IsValid && _HostedWindow.IsNormalSize && Visibility == Microsoft.UI.Xaml.Visibility.Visible;
     async void OnWindowUpdate()
     {
         if (_CacheWidth == 0 || _CacheHeight == 0) return; // wait for update


### PR DESCRIPTION
An easy way I could repro this was to add a few windows to US then add a terminal window and drag the terminal slowly on the tab bar to be first.   It ends up getting a size of 0,0 but not minimized.   Here when we click to activate it this checks for the bug.  I Check in the safest way I could find but I am not sure what causes it in the first place.

Requires https://github.com/Get0457/WinWrapper/pull/7 but could easily be written to work without it (just getting the flags manually).