### PR TITLE
Change the transparent manager to not use an alpha file and simplify our calls.

### DIFF
--- a/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
+++ b/UnitedSets/Windows/MainWindow.xaml.EventHandler.cs
@@ -286,8 +286,8 @@ public sealed partial class MainWindow : INotifyPropertyChanged
                 }
 				await TimerStop();
 
-				Environment.Exit(0);
-                return;
+				await Suicide();
+				return;
             case ContentDialogResult.Secondary:
                 // Close all windows
                 TabView.Visibility = Visibility.Visible;
@@ -313,8 +313,9 @@ public sealed partial class MainWindow : INotifyPropertyChanged
                 if (Tabs.Count == 0)
                 {
 					await TimerStop();
-					Environment.Exit(0);
-                    return;
+					await Suicide();
+
+					return;
                 }
                 goto default;
             default:
@@ -332,7 +333,13 @@ public sealed partial class MainWindow : INotifyPropertyChanged
                 break;
         }
     }
+	public async Task Suicide() {
+		trans_mgr?.Cleanup();
+		await Task.Delay(300);
+		Debug.WriteLine("Cleanish exit");
+		Environment.Exit(0);
 
+	}
     [Event(typeof(SizeChangedEventHandler))]
     void TabView_SizeChanged()
     {

--- a/UnitedSets/Windows/MainWindow.xaml.cs
+++ b/UnitedSets/Windows/MainWindow.xaml.cs
@@ -158,19 +158,12 @@ public sealed partial class MainWindow : INotifyPropertyChanged
 		Canvas.SetZIndex(border, -5);
 		MainAreaBorder.Margin = new(8, 0, 8, 8);
 		RootGrid.Children.Insert(0, border);
-		trans_mgr = new(this, swapChainPanel, System.IO.Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), @"Assets\NearTransparentBG.png"), FeatureFlags.ENTIRE_WINDOW_DRAGGABLE);
+		trans_mgr = new(this, swapChainPanel, FeatureFlags.ENTIRE_WINDOW_DRAGGABLE);
 		trans_mgr.AfterInitialize();
 
 	}
 
-	private async void TransparentFinalize() {
-		var width = this.Width;
-		var height = this.Height;
-		trans_mgr.RemoveBorderSetTransparentMap();
-		Width = width;
-		Height = height;
 
-	}
 
 	
 	private void WireTabEvents(TabBase tab) {


### PR DESCRIPTION
WinUI doesn't listen to most GDI rules so we can just go with our EXLayered to remove the items needed.

Also rewrote our exit to free the Transparent d3d items at least before exit (prevent the debug exception from firing).