### PR TITLE
Improve hosted window switching

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="github-getget99" value="https://nuget.pkg.github.com/GetGet99/index.json" />
+    <add key="github-gtudios-ui" value="https://nuget.pkg.github.com/Gtudios-UI/index.json" />
+  </packageSources>
+  <packageSourceCredentials>
+    <github-getget99>
+      <add key="Username" value="github" />
+      <add key="ClearTextPassword" value="%GITHUB_PACKAGES_TOKEN%" />
+    </github-getget99>
+    <github-gtudios-ui>
+      <add key="Username" value="github" />
+      <add key="ClearTextPassword" value="%GITHUB_PACKAGES_TOKEN%" />
+    </github-gtudios-ui>
+  </packageSourceCredentials>
+</configuration>

--- a/UnitedSets/App.xaml.cs
+++ b/UnitedSets/App.xaml.cs
@@ -26,7 +26,7 @@ public partial class App : Application
     async static void RequestAttachDebugger()
     {
         await Task.Delay(2000);
-        if (!Debugger.IsAttached)
+        if (!Debugger.IsAttached && string.Equals(Environment.GetEnvironmentVariable("UNITEDSETS_ATTACH_DEBUGGER"), "1", StringComparison.Ordinal))
             Debugger.Launch();
     }
     protected override void OnLaunched(LaunchActivatedEventArgs args)

--- a/UnitedSets/Apps/UnitedSetsApp.cs
+++ b/UnitedSets/Apps/UnitedSetsApp.cs
@@ -50,8 +50,7 @@ partial class UnitedSetsApp : INotifyPropertyChanged
     [DoesNotReturn]
     public async Task Suicide()
     {
-        //trans_mgr?.Cleanup();
-        await Task.Delay(300);
+        await Task.CompletedTask;
         Debug.WriteLine("Cleanish exit");
         Environment.Exit(0);
     }
@@ -91,10 +90,7 @@ partial class UnitedSetsApp : INotifyPropertyChanged
     public AddTabPopup AddTabPopup => field ??= new();
     public async void OpenAddTabDialog()
     {
-        MainWindow.Win32Window.Minimize();
-        await AddTabPopup.ShowAsync();
-        MainWindow.Win32Window.Restore();
-        var result = AddTabPopup.Result;
+        var result = await AddTabPopup.ShowAsync();
         if (WindowHostTab.Create(result) is { } tab)
         {
             UnitedSetsApp.Current.Tabs.Add(tab);

--- a/UnitedSets/Tabs/CellTab.Implement.cs
+++ b/UnitedSets/Tabs/CellTab.Implement.cs
@@ -36,12 +36,15 @@ partial class CellTab
     }
 
     public override void DetachAndDispose(bool JumpToCursor = false)
+        => _ = DetachAndDisposeAsync(JumpToCursor);
+
+    public override async Task DetachAndDisposeAsync(bool JumpToCursor = false)
     {
-        foreach (var cell in MainCell.AllSubCells.ToArray())
-        {
-            if (cell is WindowCell wc)
-                wc.Window.Detach();
-        }
+        await Task.WhenAll(
+            MainCell.AllSubCells
+                .OfType<WindowCell>()
+                .Select(x => x.Window.DetachAsync())
+        );
         _IsDisposed = true;
     }
 

--- a/UnitedSets/Tabs/TabBase.Abstract.cs
+++ b/UnitedSets/Tabs/TabBase.Abstract.cs
@@ -14,6 +14,7 @@ partial class TabBase
     public abstract bool IsDisposed { get; }
     
     public abstract void DetachAndDispose(bool JumpToCursor = false);
+    public abstract Task DetachAndDisposeAsync(bool JumpToCursor = false);
     ///// <summary>
     ///// Release the ownership of the window without detaching or disposing it.
     ///// </summary>

--- a/UnitedSets/Tabs/WindowHostTab.Implement.APIs.cs
+++ b/UnitedSets/Tabs/WindowHostTab.Implement.APIs.cs
@@ -9,6 +9,9 @@ partial class WindowHostTab
         => await Window.TryCloseAsync();
 
     public override async void DetachAndDispose(bool JumpToCursor)
+        => await DetachAndDisposeAsync(JumpToCursor);
+
+    public override async Task DetachAndDisposeAsync(bool JumpToCursor)
     {
         var Window = this.Window;
 		var NoMovingMode = RegisteredWindow.CompatablityMode.NoMoving;
@@ -20,8 +23,7 @@ partial class WindowHostTab
     }
     public override void Focus()
     {
-        //RegisteredWindow.SetVisible(true);
-        RegisteredWindow.Window.Focus();
+        DoShowTab();
     }
     protected override void OnDoubleClick(UIElement sender, DoubleTappedRoutedEventArgs args)
     {

--- a/UnitedSets/Tabs/WindowHostTab.cs
+++ b/UnitedSets/Tabs/WindowHostTab.cs
@@ -27,10 +27,9 @@ public partial class WindowHostTab : TabBase
         UpdateAppIcon();
     }
 
-    private async void AttemptToSelectTab()
+    private void AttemptToSelectTab()
     {
-        await Task.Delay(100);
-        UnitedSetsApp.Current.SelectedTab = this;
+        UIDispatcher.TryEnqueue(() => UnitedSetsApp.Current.SelectedTab = this);
     }
 
     public static WindowHostTab? Create(WindowEx newWindow)

--- a/UnitedSets/UI/AppWindows/MainWindow.API.Implementation.cs
+++ b/UnitedSets/UI/AppWindows/MainWindow.API.Implementation.cs
@@ -5,7 +5,6 @@ public sealed partial class MainWindow
     private partial async Task TimerStop()
     {
         timer.Stop();
-        OnUIThreadTimerLoop();
-        await Task.Delay(100);
+        await Task.CompletedTask;
     }
 }

--- a/UnitedSets/UI/AppWindows/MainWindow.EventHandler.Implementation.cs
+++ b/UnitedSets/UI/AppWindows/MainWindow.EventHandler.Implementation.cs
@@ -15,6 +15,7 @@ namespace UnitedSets.UI.AppWindows;
 /// </summary>
 public sealed partial class MainWindow
 {
+    bool _shutdownStarted;
     [RelayCommand]
     public async Task ExportData()
     {
@@ -56,9 +57,9 @@ public sealed partial class MainWindow
     private partial void TabSelectionChanged()
     {
         UnitedSetsHomeBackground.Visibility =
-                UnitedSetsApp.Current.SelectedTab is CellTab ?
-                Visibility.Collapsed :
-                Visibility.Visible;
+                UnitedSetsApp.Current.SelectedTab is null ?
+                Visibility.Visible :
+                Visibility.Collapsed;
         UpdateTitle();
     }
     private async Task SafeClose(TabBase tab)
@@ -73,7 +74,7 @@ public sealed partial class MainWindow
         catch (Exception)
         {
         }
-        tab.DetachAndDispose();
+        await tab.DetachAndDisposeAsync();
     }
 
     private partial void OnWindowClosing(AppWindowClosingEventArgs e)
@@ -88,33 +89,31 @@ public sealed partial class MainWindow
         else
             RequestCloseAsync(UnitedSetsCloseMode.ReleaseWindow);
     }
-    [DoesNotReturn]
     public async void RequestCloseAsync(UnitedSetsCloseMode closeMode)
     {
+        if (_shutdownStarted) return;
+        _shutdownStarted = true;
         ClosingFlyout.Hide();
+        var tabs = UnitedSetsApp.Current.Tabs
+            .Concat(UnitedSetsApp.Current.HiddenTabs.SelectMany(x => x.Tabs))
+            .Distinct()
+            .ToArray();
         switch (closeMode)
         {
             case UnitedSetsCloseMode.ReleaseWindow:
-                // Release all windows
-                while (UnitedSetsApp.Current.Tabs.Count > 0)
-                {
-                    var Tab = UnitedSetsApp.Current.Tabs.First();
-                    UnitedSetsApp.Current.Tabs.Remove(Tab);
-                    Tab.DetachAndDispose(JumpToCursor: false);
-                }
                 await TimerStop();
-
+                await Task.WhenAll(tabs.Select(x => x.DetachAndDisposeAsync(JumpToCursor: false)));
+                UnitedSetsApp.Current.Tabs.Clear();
+                UnitedSetsApp.Current.HiddenTabs.Clear();
                 await UnitedSetsApp.Current.Suicide();
-
                 return;
             case UnitedSetsCloseMode.CloseWindow:
-                // Close all windows
-                await Task.Delay(100);
-                await Task.WhenAll(UnitedSetsApp.Current.Tabs.ToArray().Select(SafeClose));
+                await TimerStop();
+                await Task.WhenAll(tabs.Select(SafeClose));
                 await UnitedSetsApp.Current.Suicide();
                 return;
             case UnitedSetsCloseMode.SaveCloseWindow:
-                UnitedSetsApp.Current.Configuration.SaveCurrentSession();
+                await Task.Run(UnitedSetsApp.Current.Configuration.SaveCurrentSession);
                 goto case UnitedSetsCloseMode.CloseWindow;
             default:
                 throw new ArgumentOutOfRangeException(nameof(closeMode));

--- a/UnitedSets/UI/Controls/TabVisualizer.cs
+++ b/UnitedSets/UI/Controls/TabVisualizer.cs
@@ -2,33 +2,193 @@ using UnitedSets.Cells.Data;
 using UnitedSets.Tabs;
 using UnitedSets.UI.Controls.Cells;
 using WindowHoster;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Runtime.InteropServices;
 
 namespace UnitedSets.UI.Controls;
 [DependencyProperty<TabBase>("Tab", UseNullableReferenceType = true, GenerateLocalOnPropertyChangedMethod = true)]
 public partial class TabVisualizer : TemplateControl<Grid>
 {
     Grid? rootElement;
+    readonly Dictionary<TabBase, UIElement> _cachedVisuals = [];
+    nint _thumbnail;
+    nint _thumbnailSource;
+
     protected override void Initialize(Grid rootElement)
     {
         this.rootElement = rootElement;
+        SizeChanged += (_, _) => UpdateThumbnailBounds();
+        Unloaded += (_, _) => ClearThumbnail();
         OnTabChanged(null, Tab);
     }
+
+    UIElement GetOrCreateVisual(TabBase tab)
+    {
+        if (_cachedVisuals.TryGetValue(tab, out var cached))
+            return cached;
+
+        UIElement visual = tab switch
+        {
+            CellTab ct => (UIElement)new GenericCellVisualizer(ct.MainCell).WithCustomCode(vis =>
+            {
+                ct.MainCellProperty.ApplyAndRegisterForNewValue(x => vis.Cell = x);
+                ct.CellMarginProperty.ApplyAndRegisterForNewValue(x => vis.CellMargin = x);
+            }),
+            WindowHostTab wt => (UIElement)new WindowHost { AssociatedWindow = wt.RegisteredWindow },
+            _ => throw new System.InvalidCastException("Unknown tab type")
+        };
+
+        _cachedVisuals[tab] = visual;
+        return visual;
+    }
+
+    void SetAllVisualsHiddenExcept(UIElement? toShow)
+    {
+        if (rootElement is null) return;
+        foreach (var child in rootElement.Children)
+        {
+            var isSelected = child == toShow;
+            child.Opacity = isSelected ? 1 : 0;
+            child.IsHitTestVisible = isSelected;
+        }
+    }
+
+    static void ActivateWindows(TabBase tab)
+    {
+        foreach (var window in tab.Windows)
+        {
+            if (window.IsValid)
+            {
+                if (IsIconic(window.Handle))
+                    _ = ShowWindowAsync(window.Handle, 9);
+                _ = SetWindowPos(window.Handle, 0, 0, 0, 0, 0, 0x0001 | 0x0002 | 0x4000);
+                _ = SetForegroundWindow(window.Handle);
+            }
+        }
+    }
+
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetWindowPos(nint window, nint insertAfter, int x, int y, int width, int height, uint flags);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsIconic(nint window);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ShowWindowAsync(nint window, int command);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetForegroundWindow(nint window);
+
+    void UpdateThumbnail(TabBase tab)
+    {
+        if (tab is WindowHostTab windowTab && windowTab.RegisteredWindow.UsesOwnerHosting)
+        {
+            ClearThumbnail();
+            return;
+        }
+
+        var source = tab.Windows.FirstOrDefault(x => x.IsValid).Handle;
+        if (source == 0 || XamlRoot is null) return;
+
+        if (_thumbnailSource == source)
+        {
+            UpdateThumbnailBounds();
+            return;
+        }
+
+        var destination = (nint)XamlRoot.ContentIslandEnvironment.AppWindowId.Value;
+        if (DwmRegisterThumbnail(destination, source, out var thumbnail) != 0)
+            return;
+
+        var oldThumbnail = _thumbnail;
+        _thumbnail = thumbnail;
+        _thumbnailSource = source;
+        UpdateThumbnailBounds();
+        if (oldThumbnail != 0)
+            _ = DwmUnregisterThumbnail(oldThumbnail);
+    }
+
+    void UpdateThumbnailBounds()
+    {
+        if (_thumbnail == 0 || XamlRoot?.Content is not FrameworkElement root) return;
+
+        var position = TransformToVisual(root).TransformPoint(default);
+        var scale = XamlRoot.RasterizationScale;
+        var properties = new DwmThumbnailProperties
+        {
+            Flags = 0x00000001 | 0x00000008 | 0x00000010,
+            Destination = new NativeRect
+            {
+                Left = (int)Math.Round(position.X * scale),
+                Top = (int)Math.Round(position.Y * scale),
+                Right = (int)Math.Round((position.X + ActualWidth) * scale),
+                Bottom = (int)Math.Round((position.Y + ActualHeight) * scale)
+            },
+            Visible = 1,
+            SourceClientAreaOnly = 0
+        };
+        _ = DwmUpdateThumbnailProperties(_thumbnail, ref properties);
+    }
+
+    void ClearThumbnail()
+    {
+        if (_thumbnail != 0)
+            _ = DwmUnregisterThumbnail(_thumbnail);
+        _thumbnail = 0;
+        _thumbnailSource = 0;
+    }
+
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmRegisterThumbnail(nint destination, nint source, out nint thumbnail);
+
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmUnregisterThumbnail(nint thumbnail);
+
+    [LibraryImport("dwmapi.dll")]
+    private static partial int DwmUpdateThumbnailProperties(nint thumbnail, ref DwmThumbnailProperties properties);
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct NativeRect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct DwmThumbnailProperties
+    {
+        public uint Flags;
+        public NativeRect Destination;
+        public NativeRect Source;
+        public byte Opacity;
+        public int Visible;
+        public int SourceClientAreaOnly;
+    }
+
     partial void OnTabChanged(TabBase? oldValue, TabBase? newValue)
     {
         if (rootElement is null) return;
-        rootElement.Children.Clear();
-        if (newValue != null)
-            rootElement.Children.Add(
-                newValue switch
-                {
-                    CellTab ct => new GenericCellVisualizer(ct.MainCell).WithCustomCode(vis =>
-                    {
-                        ct.MainCellProperty.ApplyAndRegisterForNewValue(x => vis.Cell = x);
-                        ct.CellMarginProperty.ApplyAndRegisterForNewValue(x => vis.CellMargin = x);
-                    }),
-                    WindowHostTab wt => new WindowHost { AssociatedWindow = wt.RegisteredWindow },
-                    _ => throw new System.InvalidCastException("Unknown tab type")
-                }
-            );
+
+        if (newValue is null)
+        {
+            ClearThumbnail();
+            SetAllVisualsHiddenExcept(null);
+            return;
+        }
+
+        var visual = GetOrCreateVisual(newValue);
+        if (!rootElement.Children.Contains(visual))
+            rootElement.Children.Add(visual);
+
+        SetAllVisualsHiddenExcept(visual);
+        UpdateThumbnail(newValue);
+        ActivateWindows(newValue);
     }
 }

--- a/UnitedSets/UI/Popups/AddTabPopup.xaml.cs
+++ b/UnitedSets/UI/Popups/AddTabPopup.xaml.cs
@@ -11,16 +11,15 @@ namespace UnitedSets.UI.Popups;
 public sealed partial class AddTabPopup
 {
     public WindowEx Result;
+    TaskCompletionSource<WindowEx>? _completion;
 
     public AddTabPopup()
     {
         UnitedSetsApp.Current.RegisterUnitedSetsWindow(WindowEx.FromWindowHandle((nint)AppWindow.Id.Value));
         InitializeComponent();
-        LowLevelKeyboard.KeyPressed += OnKeyPressed;
-        this.SetForegroundWindow();
         this.CenterOnScreen();
         AppWindow.Move(new PointInt32(AppWindow.Position.X, 80));
-        AppWindow.Closing += (_, _) => LowLevelKeyboard.KeyPressed -= OnKeyPressed;
+        AppWindow.Closing += (_, _) => Complete(default);
         SystemBackdrop = new InfiniteSystemBackdrop<MicaController>();
         this.Hide();
     }
@@ -29,25 +28,44 @@ public sealed partial class AddTabPopup
     {
         if (state == KeyboardState.KeyDown)
         {
-            if (eventDetails.KeyCode is VirtualKey.Tab or VirtualKey.ESCAPE && AppWindow.IsVisible)
+            if (eventDetails.KeyCode is VirtualKey.Tab or VirtualKey.ESCAPE && _completion is not null)
             {
-				Handled = true; //don't pass the tab through
-                Result = WindowEx.GetWindowFromPoint(Cursor.Position);
-                this.Hide();
+                Handled = true;
+                var result = eventDetails.KeyCode == VirtualKey.ESCAPE
+                    ? default
+                    : WindowEx.GetWindowFromPoint(Cursor.Position);
+                DispatcherQueue.TryEnqueue(() => Complete(result));
             }
         }
     }
 
-    public async ValueTask ShowAsync()
+    public Task<WindowEx> ShowAsync()
     {
+        if (_completion is not null)
+            return _completion.Task;
+
         Result = default;
+        _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        LowLevelKeyboard.KeyPressed += OnKeyPressed;
         this.CenterOnScreen();
         AppWindow.Move(new PointInt32(AppWindow.Position.X, 80));
         AppWindow.Show();
-        while (AppWindow.IsVisible)
-            await Task.Delay(1000);
+        this.SetForegroundWindow();
+        return _completion.Task;
+    }
+
+    void Complete(WindowEx result)
+    {
+        var completion = _completion;
+        if (completion is null) return;
+
+        _completion = null;
+        Result = result;
+        LowLevelKeyboard.KeyPressed -= OnKeyPressed;
+        this.Hide();
+        completion.TrySetResult(result);
     }
 
     [Event(typeof(RoutedEventHandler))]
-    private void CancelClick() => this.Hide();
+    private void CancelClick() => Complete(default);
 }

--- a/UnitedSets/UnitedSets.csproj
+++ b/UnitedSets/UnitedSets.csproj
@@ -27,9 +27,22 @@
         <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
         <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Platform)'==''">
+        <Platform>x64</Platform>
+    </PropertyGroup>
     <ItemGroup>
         <Compile Remove="UI\AppWindows\NewWindow.xaml.cs" />
     </ItemGroup>
+    <Target Name="PatchBrokenGetUiDataWasdkRuntimeLayout" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <_GetUiDataWasdkRuntimeRoot>$(NuGetPackageRoot)get.ui.data.wasdk\1.0.7\lib\net8.0-windows10.0.22621\Get.UI.Data.WASDK\runtimes</_GetUiDataWasdkRuntimeRoot>
+            <_WebView2RuntimeRoot>$(NuGetPackageRoot)microsoft.web.webview2\1.0.3179.45\runtimes</_WebView2RuntimeRoot>
+        </PropertyGroup>
+        <MakeDir Directories="$(_GetUiDataWasdkRuntimeRoot)\win-x86\native;$(_GetUiDataWasdkRuntimeRoot)\win-x64\native;$(_GetUiDataWasdkRuntimeRoot)\win-arm64\native" />
+        <Copy SourceFiles="$(_WebView2RuntimeRoot)\win-x86\native\WebView2Loader.dll" DestinationFiles="$(_GetUiDataWasdkRuntimeRoot)\win-x86\native\WebView2Loader.dll" SkipUnchangedFiles="true" Condition="Exists('$(_WebView2RuntimeRoot)\\win-x86\\native\\WebView2Loader.dll')" />
+        <Copy SourceFiles="$(_WebView2RuntimeRoot)\win-x64\native\WebView2Loader.dll" DestinationFiles="$(_GetUiDataWasdkRuntimeRoot)\win-x64\native\WebView2Loader.dll" SkipUnchangedFiles="true" Condition="Exists('$(_WebView2RuntimeRoot)\\win-x64\\native\\WebView2Loader.dll')" />
+        <Copy SourceFiles="$(_WebView2RuntimeRoot)\win-arm64\native\WebView2Loader.dll" DestinationFiles="$(_GetUiDataWasdkRuntimeRoot)\win-arm64\native\WebView2Loader.dll" SkipUnchangedFiles="true" Condition="Exists('$(_WebView2RuntimeRoot)\\win-arm64\\native\\WebView2Loader.dll')" />
+    </Target>
     <ItemGroup>
         <None Remove="Assets\OOBE\1.png" />
         <None Remove="UI\AppWindows\FloatingTaskbar.xaml" />
@@ -60,7 +73,7 @@
         <!--<PackageReference Include="Get.XAMLTools" Version="1.0.5" />-->
         <PackageReference Include="Enums.NET" Version="4.0.1" />
         <PackageReference Include="Get.EasyCSharp.Generator" Version="1.2.0" />
-        <PackageReference Include="Get.UI.Data.WASDK" Version="1.0.11" />
+        <PackageReference Include="Get.UI.Data.WASDK" Version="1.0.7" />
         <PackageReference Include="Get.UI.WinUI" Version="1.1.0" />
         <PackageReference Include="Get.XAMLTools.Generator" Version="1.0.5" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">

--- a/UnitedSets/Utils.cs
+++ b/UnitedSets/Utils.cs
@@ -6,7 +6,8 @@ namespace UnitedSets;
 
 static class Utils
 {
-    public static string? GetOwnerProcessModuleFilename(WindowEx window) => GetOwnerWindow(window).OwnerProcess.GetDotNetProcess.MainModule?.FileName;
+    public static string? GetOwnerProcessModuleFilename(WindowEx window)
+        => TryGetProcessMainModuleFilename(GetOwnerWindow(window));
     /// <summary>
     /// Work around WinUI/UWP as AppFrameHost is normally the owner but we want the actual app
     /// </summary>
@@ -15,7 +16,7 @@ static class Utils
     {
         var owner = window;
         wasUwp = false;
-        var mainModulePath = owner.OwnerProcess.GetDotNetProcess.MainModule?.FileName ?? "";
+        var mainModulePath = TryGetProcessMainModuleFilename(owner) ?? "";
         if (mainModulePath?.Equals(System.IO.Path.Combine(Environment.SystemDirectory, "ApplicationFrameHost.exe"), StringComparison.CurrentCultureIgnoreCase) != true)
         {
             wasUwp = mainModulePath!.Contains(WindowsAppFolder ?? LoadWindowsAppFolder(), StringComparison.CurrentCultureIgnoreCase);//some windows apps dont use appframehost, IE windows terminal
@@ -26,6 +27,19 @@ static class Utils
         var child = GetCoreWindowFromAppHostWindow(window);
         return child;
     }
+
+    static string? TryGetProcessMainModuleFilename(WindowEx window)
+    {
+        try
+        {
+            return window.OwnerProcess.GetDotNetProcess.MainModule?.FileName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public static WindowEx GetCoreWindowFromAppHostWindow(WindowEx appFrameHostMainWindow)
         => appFrameHostMainWindow.Children
         .FirstOrDefault(x => x.Class.Name is "Windows.UI.Core.CoreWindow", appFrameHostMainWindow);

--- a/WindowHoster/RegisteredWindow.cs
+++ b/WindowHoster/RegisteredWindow.cs
@@ -34,18 +34,22 @@ public partial class RegisteredWindow : INotifyPropertyChanged
         ShouldWindowBeDetachOnUserMove
     { get; set; } = (window) => true;
     internal readonly WindowStylingState InitalStylingState;
+    readonly Window InitalOwner;
     public Window Window { get; }
+    public bool UsesOwnerHosting { get; }
     [AutoNotifyProperty(SetVisibility = GeneratorVisibility.Private, OnChanged = nameof(CompatablityModeChanged))]
     CompatablityMode _CompatablityMode;
 
     private RegisteredWindow(Window WindowToHost, bool shouldBeHidden = false)
     {
         if (WindowToHost.IsMaximized)
-            WindowToHost.SendMessage(WindowMessages.SysCommand, /* SC_RESTORE */ 0xF120, 0);
+            _ = ShowWindowAsync(WindowToHost.Handle, /* SW_RESTORE */ 9);
 
         InitalStylingState = WindowStylingState.GetCurrentState(WindowToHost);
+        InitalOwner = WindowToHost.Owner;
 
         Window = WindowToHost;
+        UsesOwnerHosting = WindowToHost.Class.Name is "Chrome_WidgetWin_1";
 
         CompatablityMode = CompatablityMode with { NoMoving = NoMovingModeChecker(WindowToHost) };
 
@@ -99,13 +103,19 @@ public partial class RegisteredWindow : INotifyPropertyChanged
                 }
             }
         );
+        registeredWindowActivatedEvent = WinEvents.Register(
+            Window.Handle,
+            WinEventTypes.Foreground,
+            Window.OwnerProcess.Id == Process.Current.Id,
+            delegate { ShownByUser?.Invoke(); }
+        );
         if (shouldBeHidden && IsValid)
             WindowToHost.IsVisible = false;
         Closed += delegate { BecomesInvalid?.Invoke(); };
         Detached += delegate { BecomesInvalid?.Invoke(); };
         Properties = new(this);
     }
-    WinEventsRegistrationParameters registeredWindowClosedEvent, registeredPosSizeChangedEvent, registeredWindowShownEvent;
+    WinEventsRegistrationParameters registeredWindowClosedEvent, registeredPosSizeChangedEvent, registeredWindowShownEvent, registeredWindowActivatedEvent;
     void CompatablityModeChanged()
     {
         if (CompatablityMode.NoOwner)
@@ -118,17 +128,24 @@ public partial class RegisteredWindow : INotifyPropertyChanged
     DateTime TimeWhenGettingController = default;
     internal void InternalUpdateParent(Window parent)
     {
-        if (parent == default)
-            // replace with some window
-            parent = default;
-        var window = Window;
-        window.Owner = parent;
-        CompatablityMode = CompatablityMode with { NoOwner = Window.Owner != parent };
+        if (UsesOwnerHosting)
+        {
+            var window = Window;
+            window.Owner = parent;
+            CompatablityMode = CompatablityMode with { NoOwner = window.Owner != parent };
+            return;
+        }
+
+        // Keep games as normal top-level windows. Changing owner or taskbar styles
+        // alters activation and rendering behavior in many game engines.
+        CompatablityMode = CompatablityMode with { NoOwner = false };
     }
     private void Dispose()
     {
         registeredWindowClosedEvent.Unregister();
         registeredPosSizeChangedEvent.Unregister();
+        registeredWindowShownEvent.Unregister();
+        registeredWindowActivatedEvent.Unregister();
         IsValid = false;
     }
     /// <summary>
@@ -161,24 +178,23 @@ public partial class RegisteredWindow : INotifyPropertyChanged
     /// </summary>
     public async Task DetachAsync()
     {
-
-        var WindowToHost = Window;
-        WindowToHost.Region = InitalStylingState.Region;
-        Properties.ActivateCrop = false;
-        Properties.BorderlessWindow = false;
-        IsValid = false;
-        WindowToHost.Owner = default;
-        WindowToHost.IsResizable = InitalStylingState.IsResizable;
-        WindowToHost.IsVisible = true;
-        Dispose();
-
-        WindowToHost.Focus();
-        WindowToHost.Redraw();
-        WindowToHost.SetAsForegroundWindow();
-        await Task.Delay(100).ContinueWith(_ =>
+        lock (this)
         {
-            WindowToHost.Redraw();
-            WindowToHost.IsVisible = true;
+            if (!IsValid) return;
+            IsValid = false;
+        }
+
+        CurrentController?.Unregister();
+        var windowToHost = Window;
+        await Task.Run(() =>
+        {
+            windowToHost.Region = InitalStylingState.Region;
+            Properties.ActivateCrop = false;
+            Properties.BorderlessWindow = false;
+            windowToHost.Owner = InitalOwner;
+            InitalStylingState.RestoreTo(windowToHost);
+            windowToHost.IsVisible = true;
+            Dispose();
         });
         Detached?.Invoke();
     }
@@ -209,4 +225,9 @@ public partial class RegisteredWindow : INotifyPropertyChanged
         if (BlacklistChecker(window)) return null;
         return new(window, shouldBeHidden);
     }
+
+    [System.Runtime.InteropServices.LibraryImport("user32.dll")]
+    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+    private static partial bool ShowWindowAsync(nint window, int command);
+
 }

--- a/WindowHoster/RegisteredWindowController.cs
+++ b/WindowHoster/RegisteredWindowController.cs
@@ -11,65 +11,71 @@ namespace WindowHoster;
 
 public partial class RegisteredWindowController
 {
-    internal bool Updating { get; private set; } = false;
-    bool isRegistered = true;
+    internal bool Updating { get; private set; }
+    volatile bool isRegistered = true;
     Window Parent;
     RegisteredWindow self;
     [Property(OnChanged = nameof(CointainerRectangleChanged))]
     Windows.Foundation.Rect _ContainerRectangle;
     internal Rectangle LatestRequestedRect { get; private set; }
-    internal async void UpdatePosition()
+    internal void UpdatePosition() => updateRequested.Set();
+
+    void ApplyPosition()
     {
         if (!isRegistered) return;
         if (self.CompatablityMode.NoMoving) return;
         Updating = true;
-        var window = self.Window;
-        Point windowOffset;
-        unsafe
+        try
         {
-            _ = PInvoke.MapWindowPoints(
-                (HWND)Parent.Handle,
-                default,
-                &windowOffset,
-                1
-            );
-        }
-        var rasterizationScale = self.Window.CurrentDisplay.ScaleFactor / 100d;
-        var requestedRect = RectToScreen(ContainerRectangle, windowOffset, rasterizationScale);
-        if (self.Properties.ActivateCrop)
-        {
-            var cropRegion = self.Properties.CropRegion;
-            requestedRect = requestedRect with
+            var window = self.Window;
+            Point windowOffset;
+            unsafe
             {
-                X = requestedRect.X - cropRegion.Left,
-                Y = requestedRect.Y - cropRegion.Top,
-                Width = requestedRect.Width + cropRegion.Left + cropRegion.Right,
-                Height = requestedRect.Height + cropRegion.Top + cropRegion.Bottom
-            };
-            var currentBounds = window.Bounds;
-            if (self.Properties.ForceInvalidateCrop || currentBounds != requestedRect)
+                _ = PInvoke.MapWindowPoints(
+                    (HWND)Parent.Handle,
+                    default,
+                    &windowOffset,
+                    1
+                );
+            }
+            var rasterizationScale = self.Window.CurrentDisplay.ScaleFactor / 100d;
+            var requestedRect = RectToScreen(ContainerRectangle, windowOffset, rasterizationScale);
+            if (requestedRect.Width <= 0 || requestedRect.Height <= 0) return;
+            if (self.Properties.ActivateCrop)
             {
-                self.Properties.ForceInvalidateCrop = false;
-                _ = window.SetRegionAsync(new(
-                    cropRegion.Left,
-                    cropRegion.Top,
-                    currentBounds.Width - cropRegion.Left - cropRegion.Right,
-                    currentBounds.Height - cropRegion.Top - cropRegion.Bottom
-                ));
+                var cropRegion = self.Properties.CropRegion;
+                requestedRect = requestedRect with
+                {
+                    X = requestedRect.X - cropRegion.Left,
+                    Y = requestedRect.Y - cropRegion.Top,
+                    Width = requestedRect.Width + cropRegion.Left + cropRegion.Right,
+                    Height = requestedRect.Height + cropRegion.Top + cropRegion.Bottom
+                };
+                var currentBounds = window.Bounds;
+                if (self.Properties.ForceInvalidateCrop || currentBounds != requestedRect)
+                {
+                    self.Properties.ForceInvalidateCrop = false;
+                    _ = window.SetRegionAsync(new(
+                        cropRegion.Left,
+                        cropRegion.Top,
+                        currentBounds.Width - cropRegion.Left - cropRegion.Right,
+                        currentBounds.Height - cropRegion.Top - cropRegion.Bottom
+                    ));
+                }
+            }
+            if (LatestRequestedRect == requestedRect && window.Bounds == requestedRect) return;
+            LatestRequestedRect = requestedRect;
+            window.Bounds = requestedRect;
+            if (queueSetVisible)
+            {
+                queueSetVisible = false;
+                window.IsVisible = true;
             }
         }
-        LatestRequestedRect = requestedRect;
-        window.Bounds = requestedRect;
-        if (queueSetVisible)
+        finally
         {
-            queueSetVisible = false;
-            window.IsVisible = true;
-            // do not steal focus if we are doing things with other window
-            await Task.Delay(100);
-            if (!Cursor.IsLeftButtonDown)
-                window.SetAsForegroundWindow();
+            Updating = false;
         }
-        Updating = false;
     }
     static Rectangle RectToScreen(Windows.Foundation.Rect rect, Point WindowPosOffset, double RasterizationScale)
     {
@@ -93,36 +99,35 @@ public partial class RegisteredWindowController
         queueSetVisible = true;
         self.InternalUpdateParent(Parent);
         WinEvents.Register(Parent.Handle, WinEventTypes.PositionSizeChanged, false, ParentPositionChangedHandler);
-        thread = new(ThreadLoop);
+        thread = new(ThreadLoop) { IsBackground = true };
         thread.Start();
+        UpdatePosition();
     }
     readonly Thread thread;
     void ParentPositionChangedHandler(WinEventTypes eventType, nint hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
     {
         // we can't update immedietly when the handler is called
         // so we do it in another thread
-        queueUpdatePosition = true;
+        UpdatePosition();
     }
     void CointainerRectangleChanged()
     {
-        queueUpdatePosition = true;
+        UpdatePosition();
     }
-    bool queueUpdatePosition = false;
+    readonly AutoResetEvent updateRequested = new(false);
     void ThreadLoop()
     {
         while (isRegistered)
         {
-            if (queueUpdatePosition)
-            {
-                queueUpdatePosition = false;
-                UpdatePosition();
-            }
-            Thread.Sleep(1000 / 60);
+            updateRequested.WaitOne();
+            if (isRegistered)
+                ApplyPosition();
         }
     }
     internal void Unregister()
     {
         isRegistered = false;
+        updateRequested.Set();
         var window = self.Window;
         WinEvents.Unregister(Parent.Handle, WinEventTypes.PositionSizeChanged, false, ParentPositionChangedHandler);
         //window.DwmAttribute.Set(DwmWindowAttribute.DWMWA_CLOAK, 1);
@@ -130,6 +135,8 @@ public partial class RegisteredWindowController
             window.IsVisible = false;
         if (self.CurrentController == this)
             self.CurrentController = null;
+        if (Thread.CurrentThread != thread)
+            thread.Join(500);
         Parent = default;
         self = null!;
     }

--- a/WindowHoster/WinEvents.cs
+++ b/WindowHoster/WinEvents.cs
@@ -3,24 +3,26 @@ using Windows.Win32.UI.Accessibility;
 using Windows.Win32.Foundation;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 namespace WindowHoster;
 
 public static class WinEvents
 {
+    static readonly object Sync = new();
     readonly static Dictionary<WinEventTypes, IDisposable> UnhookFuncs = [];
     readonly static Dictionary<WinEventTypes, IDisposable> UnhookFuncsSkipOwnProcess = [];
     public static WinEventsRegistrationParameters Register(nint hwnd, WinEventTypes type, bool skipOwnProcess, WinEventHandler handler)
     {
-        EnsureWinHookRegistered(type, skipOwnProcess);
-        if (!EventRegistrations.TryGetValue((HWND)hwnd, out var registeredWindow))
+        lock (Sync)
         {
-            EventRegistrations[(HWND)hwnd] = registeredWindow = [];
-        }
-        if (registeredWindow.TryGetValue(type, out var oldHandler)) {
-            registeredWindow[type] = oldHandler + handler;
-        } else
-        {
-            registeredWindow[type] = handler;
+            EnsureWinHookRegistered(type, skipOwnProcess);
+            var registrations = skipOwnProcess ? EventRegistrationsSkipOwnProcess : EventRegistrations;
+            if (!registrations.TryGetValue((HWND)hwnd, out var registeredWindow))
+                registrations[(HWND)hwnd] = registeredWindow = [];
+            if (registeredWindow.TryGetValue(type, out var oldHandler))
+                registeredWindow[type] = oldHandler + handler;
+            else
+                registeredWindow[type] = handler;
         }
         return new(hwnd, type, skipOwnProcess, handler);
     }
@@ -28,25 +30,27 @@ public static class WinEvents
         => Unregister(param.Hwnd, param.Type, param.SkipOwnProcess, param.Handler);
     public static void Unregister(nint hwnd, WinEventTypes type, bool skipOwnProcess, WinEventHandler handler)
     {
-        if (!EventRegistrations.TryGetValue((HWND)hwnd, out var registeredWindow)) return;
-        if (registeredWindow.TryGetValue(type, out var oldHandler))
+        lock (Sync)
         {
+            var registrations = skipOwnProcess ? EventRegistrationsSkipOwnProcess : EventRegistrations;
+            if (!registrations.TryGetValue((HWND)hwnd, out var registeredWindow) ||
+                !registeredWindow.TryGetValue(type, out var oldHandler)) return;
             var newHandler = oldHandler - handler;
             if (newHandler is null)
             {
                 registeredWindow.Remove(type);
-                
-                if (UnhookFuncs.TryGetValue(type, out var disposable)) {
-                    UnhookFuncs.Remove(type);
+                if (registeredWindow.Count == 0)
+                    registrations.Remove((HWND)hwnd);
+
+                if (!registrations.Values.Any(x => x.ContainsKey(type)))
+                {
+                    var unhookFunctions = skipOwnProcess ? UnhookFuncsSkipOwnProcess : UnhookFuncs;
+                    if (!unhookFunctions.Remove(type, out var disposable)) return;
                     disposable.Dispose();
                 }
             }
             else
                 registeredWindow[type] = newHandler;
-        }
-        else
-        {
-            registeredWindow[type] = handler;
         }
     }
     static void EnsureWinHookRegistered(WinEventTypes type, bool skipOwnProcess)
@@ -89,12 +93,11 @@ public static class WinEvents
         uint dwmsEventTime
     )
     {
-        if (
-            EventRegistrations.TryGetValue(hwnd, out var registeredWindow) &&
-            registeredWindow.TryGetValue((WinEventTypes)@event, out var handler))
-        {
-            handler((WinEventTypes)@event, hwnd, idObject, idChild, idEventThread, dwmsEventTime);
-        }
+        WinEventHandler? handler;
+        lock (Sync)
+            handler = EventRegistrations.TryGetValue(hwnd, out var registeredWindow) &&
+                registeredWindow.TryGetValue((WinEventTypes)@event, out var found) ? found : null;
+        handler?.Invoke((WinEventTypes)@event, hwnd, idObject, idChild, idEventThread, dwmsEventTime);
     }
     static void EventCallbackSkipOwnProcess(
         HWINEVENTHOOK hWinEventHook,
@@ -106,12 +109,11 @@ public static class WinEvents
         uint dwmsEventTime
     )
     {
-        if (
-            EventRegistrationsSkipOwnProcess.TryGetValue(hwnd, out var registeredWindow) &&
-            registeredWindow.TryGetValue((WinEventTypes)@event, out var handler))
-        {
-            handler((WinEventTypes)@event, hwnd, idObject, idChild, idEventThread, dwmsEventTime);
-        }
+        WinEventHandler? handler;
+        lock (Sync)
+            handler = EventRegistrationsSkipOwnProcess.TryGetValue(hwnd, out var registeredWindow) &&
+                registeredWindow.TryGetValue((WinEventTypes)@event, out var found) ? found : null;
+        handler?.Invoke((WinEventTypes)@event, hwnd, idObject, idChild, idEventThread, dwmsEventTime);
     }
 }
 public delegate void WinEventHandler(WinEventTypes eventType, nint hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime);
@@ -121,7 +123,8 @@ public enum WinEventTypes : uint
     WindowMovedStart = PInvoke.EVENT_SYSTEM_MOVESIZESTART,
     NameChanged = PInvoke.EVENT_OBJECT_NAMECHANGE,
     ObjectDestroyed = PInvoke.EVENT_OBJECT_DESTROY,
-    WindowShown = PInvoke.EVENT_OBJECT_SHOW
+    WindowShown = PInvoke.EVENT_OBJECT_SHOW,
+    Foreground = 0x0003
 }
 public readonly record struct WinEventsRegistrationParameters(nint Hwnd, WinEventTypes Type, bool SkipOwnProcess, WinEventHandler Handler)
 {

--- a/WindowHoster/WindowHost.cs
+++ b/WindowHoster/WindowHost.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System;
 using Get.XAMLTools;
 using Microsoft.UI.Xaml;
 using Windows.Foundation;
@@ -45,27 +46,19 @@ public partial class WindowHost : FrameworkElement
         controller.ContainerRectangle = cachedContainerRectangle;
     }
 
-    async partial void OnAssociatedWindowChanged(RegisteredWindow? oldValue, RegisteredWindow? newValue)
+    partial void OnAssociatedWindowChanged(RegisteredWindow? oldValue, RegisteredWindow? newValue)
     {
         Controller = null;
         if (oldValue is not null)
             oldValue.BecomesInvalid -= RemoveController;
-        if (IsLoaded)
+        if (IsLoaded && newValue is not null)
         {
-            if (newValue is not null)
-                newValue.BecomesInvalid += RemoveController;
-            while (true)
+            newValue.BecomesInvalid += RemoveController;
+            try
             {
-                try
-                {
-                    Controller = newValue?.GetController(ParentWindow, DispatcherQueue);
-                    break;
-                }
-                catch
-                {
-                    await Task.Delay(1000);
-                }
+                Controller = newValue.GetController(ParentWindow, DispatcherQueue);
             }
+            catch (InvalidOperationException) { }
         }
     }
 
@@ -98,29 +91,28 @@ public partial class WindowHost : FrameworkElement
     }
     private void WindowHost_Unloaded(object sender, RoutedEventArgs e)
     {
+        if (AssociatedWindow is { } window)
+            window.BecomesInvalid -= RemoveController;
+        if (XamlRoot is not null)
+            XamlRoot.Changed -= XamlRoot_Changed;
         Controller = null;
     }
 
-    private async void WindowHost_Loaded(object sender, RoutedEventArgs e)
+    private void WindowHost_Loaded(object sender, RoutedEventArgs e)
     {
         Controller = null;
         Update(); // update position
         if (AssociatedWindow is { } window)
         {
+            window.BecomesInvalid -= RemoveController;
             window.BecomesInvalid += RemoveController;
-            while (true)
+            try
             {
-                try
-                {
-                    Controller = window.GetController(ParentWindow, DispatcherQueue);
-                    break;
-                }
-                catch
-                {
-                    await Task.Delay(1000);
-                }
+                Controller = window.GetController(ParentWindow, DispatcherQueue);
             }
+            catch (InvalidOperationException) { }
         }
+        XamlRoot.Changed -= XamlRoot_Changed;
         XamlRoot.Changed += XamlRoot_Changed;
     }
     bool wasVisible;


### PR DESCRIPTION
made these changes to allow smoother operation when dealing with tabs of games, removing a lot of friction to make seamless tab switching possible and also fixed compatibility with some games that were not able to be detected when adding a tab

also made the add tab less involved, since when having several games tabs minimizing all of them made the flow too convoluted and heavy

not sure if this would be neccesarily added as it is to mainstream but some ideas that might be implemented in a better way

thanks!